### PR TITLE
Enable colors for output logs

### DIFF
--- a/src/resources/js/app.js
+++ b/src/resources/js/app.js
@@ -430,7 +430,7 @@ const Run = function() {
   };
   var firstLog = false;
   var logHandler = function(vm, d) {
-    state.log += d;
+    state.log += ansi_up.ansi_to_html(d);
     vm.$forceUpdate();
     if (!firstLog) {
       firstLog = true;


### PR DESCRIPTION
Colored logs were the only thing I was missing on this really simple and easy-to-use ci tool - was looking for something similar for ages, thanks!

From the other hand, my solution has one small bug - if the build is running, and the color is unterminared (for example, three red lines) and is split into few websocket frames, then every frame starts again with with black on white - after page refresh, it is okay. 

I could add another variable (for example rawLog) and append log here, then convert whole varriable into log html pre. But i'm not sure about vuejs principes, so I didn't do it. 

I'm attaching two screens as how it is looking. The first one is captured during the run (there should be more of red color), the second one is how it looks after page refresh. If you are interested, I can try to fix it, I'd like to help a little with this project, becose I like Laminar a lot. 

```bash
#!/bin/bash -ex

RED='\033[0;31m'
NC='\033[0m' # No Color
sleep 2
printf "Still remains ${RED}RED!\n"
sleep 5
printf "Still red. ${NC}And white\n"
```

![snimek z 2017-12-20 12-25-24](https://user-images.githubusercontent.com/2713846/34242719-52375390-e61d-11e7-9b10-6e3fcb1dc240.png)
![snimek z 2017-12-20 12-25-32](https://user-images.githubusercontent.com/2713846/34242720-524eba1c-e61d-11e7-9156-fae80f8d5f22.png)

