### PR TITLE
Fix archive url: missing slash

### DIFF
--- a/etc/laminar.conf
+++ b/etc/laminar.conf
@@ -51,4 +51,4 @@
 ### uses a very naive and inefficient method. Best to let a real
 ### webserver handle serving those requests.
 ###
-#LAMINAR_ARCHIVE_URL=http://backbone.example.com/ci/archive
+#LAMINAR_ARCHIVE_URL=http://backbone.example.com/ci/archive/

--- a/src/laminar.cpp
+++ b/src/laminar.cpp
@@ -80,6 +80,9 @@ Laminar::Laminar(const char *home) :
     archiveUrl = ARCHIVE_URL_DEFAULT;
     if(char* envArchive = getenv("LAMINAR_ARCHIVE_URL"))
         archiveUrl = envArchive;
+	if(archiveUrl.back() != '/')
+		archiveUrl.append("/");
+
     numKeepRunDirs = 0;
 
     db = new Database((homePath/"laminar.sqlite").toString(true).cStr());

--- a/src/laminar.cpp
+++ b/src/laminar.cpp
@@ -56,7 +56,7 @@ namespace {
 // Default values when none were supplied in $LAMINAR_CONF_FILE (/etc/laminar.conf)
 constexpr const char* INTADDR_RPC_DEFAULT = "unix-abstract:laminar";
 constexpr const char* INTADDR_HTTP_DEFAULT = "*:8080";
-constexpr const char* ARCHIVE_URL_DEFAULT = "/archive";
+constexpr const char* ARCHIVE_URL_DEFAULT = "/archive/";
 }
 
 // short syntax helpers for kj::Path
@@ -78,10 +78,11 @@ Laminar::Laminar(const char *home) :
     KJ_ASSERT(home[0] == '/');
 
     archiveUrl = ARCHIVE_URL_DEFAULT;
-    if(char* envArchive = getenv("LAMINAR_ARCHIVE_URL"))
+    if(char* envArchive = getenv("LAMINAR_ARCHIVE_URL")) {
         archiveUrl = envArchive;
-	if(archiveUrl.back() != '/')
-		archiveUrl.append("/");
+        if(archiveUrl.back() != '/')
+            archiveUrl.append("/");
+    }
 
     numKeepRunDirs = 0;
 


### PR DESCRIPTION
As mentioned in issue #86 - automatic fix of missing slash in archive url. 