### PR TITLE
Checks for an existing config file before overwriting.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,8 +104,12 @@ if(BUILD_TESTS)
 endif()
 
 set(SYSTEMD_UNITDIR lib/systemd/system CACHE PATH "Path to systemd unit files")
+
 set(BASH_COMPLETIONS_DIR usr/share/bash-completion/completions CACHE PATH "Path to bash completions directory")
 set(ZSH_COMPLETIONS_DIR usr/share/zsh/site-functions CACHE PATH "Path to zsh completions directory")
+install(FILES etc/laminarc-completion.bash DESTINATION ${BASH_COMPLETIONS_DIR} RENAME laminarc)
+install(FILES etc/laminarc-completion.zsh DESTINATION ${ZSH_COMPLETIONS_DIR} RENAME _laminarc)
+
 install(TARGETS laminard laminarc RUNTIME DESTINATION usr/bin)
 install(FILES etc/laminar.service DESTINATION ${SYSTEMD_UNITDIR})
 
@@ -127,5 +131,3 @@ else()
     )
 endif()
 
-install(FILES etc/laminarc-completion.bash DESTINATION ${BASH_COMPLETIONS_DIR} RENAME laminarc)
-install(FILES etc/laminarc-completion.zsh DESTINATION ${ZSH_COMPLETIONS_DIR} RENAME _laminarc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,21 +123,12 @@ install(FILES etc/laminarc-completion.zsh DESTINATION ${ZSH_COMPLETIONS_DIR} REN
 install(TARGETS laminard laminarc RUNTIME DESTINATION usr/bin)
 install(FILES etc/laminar.service DESTINATION ${SYSTEMD_UNITDIR})
 
-# An initial attempt at solving https://github.com/ohwgiles/laminar/issues/92
+# Don't overwrite the config file if it already exists at the target location
+# @todo - migration/override script if the defaults change or the options get pruned?
 if(NOT EXISTS "${CMAKE_INSTALL_PREFIX}etc/laminar.conf")
     install(
-        FILES ${CMAKE_INSTALL_PREFIX}etc/laminar.conf
-        DESTINATION etc
-    )
-else(NOT EXISTS "${CMAKE_INSTALL_PREFIX}etc/laminar.conf")
-    # hardcoded values are examples of technical debt, and in an ideal world, are eliminated.
-    MESSAGE("-- A ${CMAKE_INSTALL_PREFIX}etc/laminar.conf file exists, will create ${CMAKE_INSTALL_PREFIX}etc/laminar.conf.example instead of overwriting.")
-    # This also displays at config time, rather than install time.
-    # In an ideal world, the user gets offered the option to overwrite, compare, or keep/copy the file
-    install(
-        FILES ${CMAKE_INSTALL_PREFIX}etc/laminar.conf
-        DESTINATION etc
-        RENAME "laminar.conf.example"
+        FILES etc/laminar.conf
+        DESTINATION ${CMAKE_INSTALL_PREFIX}etc
     )
 endif(NOT EXISTS "${CMAKE_INSTALL_PREFIX}etc/laminar.conf")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,12 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 if(NOT CMAKE_INSTALL_PREFIX)
     set(CMAKE_INSTALL_PREFIX /)
 endif(NOT CMAKE_INSTALL_PREFIX)
+message("-- Install prefix set to '${CMAKE_INSTALL_PREFIX}'")
 
-message("-- Install prefix set to ${CMAKE_INSTALL_PREFIX}")
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release )
+endif(NOT CMAKE_BUILD_TYPE)
+message("-- Install type set to '${CMAKE_BUILD_TYPE}'")
 
 add_definitions("-std=c++14 -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Werror -DDEBUG")
@@ -120,20 +124,20 @@ install(TARGETS laminard laminarc RUNTIME DESTINATION usr/bin)
 install(FILES etc/laminar.service DESTINATION ${SYSTEMD_UNITDIR})
 
 # An initial attempt at solving https://github.com/ohwgiles/laminar/issues/92
-if(NOT EXISTS "/etc/laminar.conf")
+if(NOT EXISTS "${CMAKE_INSTALL_PREFIX}etc/laminar.conf")
     install(
-        FILES etc/laminar.conf
+        FILES ${CMAKE_INSTALL_PREFIX}etc/laminar.conf
         DESTINATION etc
     )
-else()
+else(NOT EXISTS "${CMAKE_INSTALL_PREFIX}etc/laminar.conf")
     # hardcoded values are examples of technical debt, and in an ideal world, are eliminated.
-    MESSAGE("-- An /etc/laminar.conf file exists, will create /etc/laminar.conf.example instead of overwriting.")
+    MESSAGE("-- A ${CMAKE_INSTALL_PREFIX}etc/laminar.conf file exists, will create ${CMAKE_INSTALL_PREFIX}etc/laminar.conf.example instead of overwriting.")
     # This also displays at config time, rather than install time.
     # In an ideal world, the user gets offered the option to overwrite, compare, or keep/copy the file
     install(
-        FILES etc/laminar.conf
+        FILES ${CMAKE_INSTALL_PREFIX}etc/laminar.conf
         DESTINATION etc
         RENAME "laminar.conf.example"
     )
-endif()
+endif(NOT EXISTS "${CMAKE_INSTALL_PREFIX}etc/laminar.conf")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,12 @@ cmake_policy(SET CMP0058 NEW)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+if(NOT CMAKE_INSTALL_PREFIX)
+    set(CMAKE_INSTALL_PREFIX /)
+endif(NOT CMAKE_INSTALL_PREFIX)
+
+message("-- Install prefix set to ${CMAKE_INSTALL_PREFIX}")
+
 add_definitions("-std=c++14 -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Werror -DDEBUG")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,24 @@ set(BASH_COMPLETIONS_DIR usr/share/bash-completion/completions CACHE PATH "Path 
 set(ZSH_COMPLETIONS_DIR usr/share/zsh/site-functions CACHE PATH "Path to zsh completions directory")
 install(TARGETS laminard laminarc RUNTIME DESTINATION usr/bin)
 install(FILES etc/laminar.service DESTINATION ${SYSTEMD_UNITDIR})
-install(FILES etc/laminar.conf DESTINATION etc)
+
+# An initial attempt at solving https://github.com/ohwgiles/laminar/issues/92
+if(NOT EXISTS "/etc/laminar.conf")
+    install(
+        FILES etc/laminar.conf
+        DESTINATION etc
+    )
+else()
+    # hardcoded values are examples of technical debt, and in an ideal world, are eliminated.
+    MESSAGE("-- An /etc/laminar.conf file exists, will create /etc/laminar.conf.example instead of overwriting.")
+    # This also displays at config time, rather than install time.
+    # In an ideal world, the user gets offered the option to overwrite, compare, or keep/copy the file
+    install(
+        FILES etc/laminar.conf
+        DESTINATION etc
+        RENAME "laminar.conf.example"
+    )
+endif()
+
 install(FILES etc/laminarc-completion.bash DESTINATION ${BASH_COMPLETIONS_DIR} RENAME laminarc)
 install(FILES etc/laminarc-completion.zsh DESTINATION ${ZSH_COMPLETIONS_DIR} RENAME _laminarc)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ First install development packages for `capnproto (version 0.7.0 or newer)`, `ra
 git clone https://github.com/ohwgiles/laminar.git
 cd laminar
 cmake .
-make -j4
+make -j$(nproc)
 sudo make install
 ```
 Note that by default, installing with `(c)make` will overwrite your existing configuration, binary, and unit files. Make backups!

--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@ First install development packages for `capnproto (version 0.7.0 or newer)`, `ra
 ```bash
 git clone https://github.com/ohwgiles/laminar.git
 cd laminar
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/
+cmake .
 make -j4
 sudo make install
 ```
+Note that by default, installing with `(c)make` will overwrite your existing configuration, binary, and unit files. Make backups!
+
+The CMakeLists.txt file sets `cmake` defaults to `CMAKE_INSTALL_PREFIX=/` and `CMAKE_BUILD_TYPE=Release`, which can be overridden with the `-DCMAKE_INSTALL_PREFIX=<path>` and `-DCMAKE_BUILD_TYPE=<type>` flags, respectively.
 
 `make install` includes a systemd unit file. If you intend to use it, consider creating a new user `laminar` or modifying the user specified in the unit file.
 


### PR DESCRIPTION
Checks for the existence of an `/etc/laminar.conf` file before writing, and writes to `/etc/laminar.conf.example` should the default file already exist.

Should technically resolve #92, but might be better off standardized for all config/service/autocomplete files.

My cursory examination of the `cmake` system failed to turn up an easy-ish way to obtain user input and alter the outcome accordingly (eg, merge or copy the new/default config over top of the potentially-edited file), or even to check if the existing file is modified.

Open to suggestions on a better way to do this.  
Can't say I'm a fan of cmake so far.  

:-/