### PR TITLE
fix debian package filename and contained version

### DIFF
--- a/docker-build-debian.sh
+++ b/docker-build-debian.sh
@@ -4,7 +4,7 @@ OUTPUT_DIR=$PWD
 
 SOURCE_DIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 
-VERSION=$(cd "$SOURCE_DIR" && git describe --tags --abbrev=8 --dirty)
+VERSION=$(cd "$SOURCE_DIR" && git describe --tags --abbrev=8 --dirty)-1~upstream-debian9
 
 DOCKER_TAG=$(docker build -q - <<EOS
 FROM debian:9-slim
@@ -45,7 +45,7 @@ make DESTDIR=laminar install/strip
 mkdir laminar/DEBIAN
 cat <<EOF > laminar/DEBIAN/control
 Package: laminar
-Version: $VERSION-1
+Version: $VERSION
 Section: 
 Priority: optional
 Architecture: amd64
@@ -63,5 +63,5 @@ EOF
 chmod +x laminar/DEBIAN/postinst
 
 dpkg-deb --build laminar
-mv laminar.deb /output/laminar_$VERSION-1_amd64.deb
+mv laminar.deb /output/laminar_$VERSION_amd64.deb
 EOS

--- a/docker-build-debian.sh
+++ b/docker-build-debian.sh
@@ -45,7 +45,7 @@ make DESTDIR=laminar install/strip
 mkdir laminar/DEBIAN
 cat <<EOF > laminar/DEBIAN/control
 Package: laminar
-Version: $VERSION
+Version: $VERSION-1
 Section: 
 Priority: optional
 Architecture: amd64
@@ -63,5 +63,5 @@ EOF
 chmod +x laminar/DEBIAN/postinst
 
 dpkg-deb --build laminar
-mv laminar.deb /output/laminar-$VERSION-1-amd64.deb
+mv laminar.deb /output/laminar_$VERSION-1_amd64.deb
 EOS

--- a/docker-xbuild-debian-armhf.sh
+++ b/docker-xbuild-debian-armhf.sh
@@ -65,7 +65,7 @@ make DESTDIR=laminar install/strip
 mkdir laminar/DEBIAN
 cat <<EOF > laminar/DEBIAN/control
 Package: laminar
-Version: $VERSION
+Version: $VERSION-1
 Section: 
 Priority: optional
 Architecture: armhf
@@ -83,5 +83,5 @@ EOF
 chmod +x laminar/DEBIAN/postinst
 
 dpkg-deb --build laminar
-mv laminar.deb /output/laminar-$VERSION-1-armhf.deb
+mv laminar.deb /output/laminar_$VERSION-1_armhf.deb
 EOS

--- a/docker-xbuild-debian-armhf.sh
+++ b/docker-xbuild-debian-armhf.sh
@@ -4,7 +4,7 @@ OUTPUT_DIR=$PWD
 
 SOURCE_DIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 
-VERSION=$(cd "$SOURCE_DIR" && git describe --tags --abbrev=8 --dirty)
+VERSION=$(cd "$SOURCE_DIR" && git describe --tags --abbrev=8 --dirty)-1~upstream-debian9
 
 DOCKER_TAG=$(docker build -q - <<EOS
 FROM debian:9-slim
@@ -65,7 +65,7 @@ make DESTDIR=laminar install/strip
 mkdir laminar/DEBIAN
 cat <<EOF > laminar/DEBIAN/control
 Package: laminar
-Version: $VERSION-1
+Version: $VERSION
 Section: 
 Priority: optional
 Architecture: armhf
@@ -83,5 +83,5 @@ EOF
 chmod +x laminar/DEBIAN/postinst
 
 dpkg-deb --build laminar
-mv laminar.deb /output/laminar_$VERSION-1_armhf.deb
+mv laminar.deb /output/laminar_$VERSION_armhf.deb
 EOS


### PR DESCRIPTION
The inner version should be the same as the one in the filename; the filename pattern is `${name}_${version}_${arch}.deb` (i.e. `_` instead of `-`).

If you want to avoid conflicts with packages from debian you could use `-0` instead of `-1` as version suffix; they should still work fine, but as soon as debian actually provides the `-1` packages apt would automatically suggest updating to the debian one.