### PR TITLE
Add the ability to customize index.html

### DIFF
--- a/UserManual.md
+++ b/UserManual.md
@@ -618,9 +618,9 @@ Change `LAMINAR_TITLE` in `/etc/laminar.conf` to your preferred page title. Lami
 
 ## Custom HTML template
 
-If it exists, the file `/var/lib/laminar/custom/index.html` will be served by laminar instead of the default markup that is bundled into the Laminar binary. This file can be used to change any aspect of Laminar's WebUI, including adding custom menu links, stylesheets, or anything else. Any additional assets that are needed will need to be served directly from your [HTTP reverse proxy](#Service-configuration) (highly recommended).
+If it exists, the file `/var/lib/laminar/custom/index.html` will be served by laminar instead of the default markup that is bundled into the Laminar binary. This file can be used to change any aspect of Laminar's WebUI, for example adding menu links or adding a custom stylesheet. Any required assets will need to be served directly from your [HTTP reverse proxy](#Service-configuration) or other HTTP server.
 
-An example of customization of both the HTML templates and CSS markup can be found at [cweagans/semantic-laminar-theme](https://github.com/cweagans/semantic-laminar-theme).
+An example customization can be found at [cweagans/semantic-laminar-theme](https://github.com/cweagans/semantic-laminar-theme).
 
 ---
 

--- a/UserManual.md
+++ b/UserManual.md
@@ -622,6 +622,10 @@ If it exists, the file `/var/lib/laminar/custom/style.css` will be served by lam
 
 This directory is also a good place to add any extra assets needed for this customization, but note that in this case you will need to serve this directory directly from your [HTTP reverse proxy](#Service-configuration) (highly recommended).
 
+## Custom HTML template
+
+If it exists, the file `/var/lib/laminar/custom/index.html` will be served by laminar instead of the default markup that is bundled into the Laminar binary. This file can be used to change any aspect of Laminar's WebUI, including adding custom menu links, stylesheets, or anything else. Any additional assets that are needed will need to be served directly from your [HTTP reverse proxy](#Service-configuration) (highly recommended). 
+
 ---
 
 # Badges

--- a/UserManual.md
+++ b/UserManual.md
@@ -624,7 +624,9 @@ This directory is also a good place to add any extra assets needed for this cust
 
 ## Custom HTML template
 
-If it exists, the file `/var/lib/laminar/custom/index.html` will be served by laminar instead of the default markup that is bundled into the Laminar binary. This file can be used to change any aspect of Laminar's WebUI, including adding custom menu links, stylesheets, or anything else. Any additional assets that are needed will need to be served directly from your [HTTP reverse proxy](#Service-configuration) (highly recommended). 
+If it exists, the file `/var/lib/laminar/custom/index.html` will be served by laminar instead of the default markup that is bundled into the Laminar binary. This file can be used to change any aspect of Laminar's WebUI, including adding custom menu links, stylesheets, or anything else. Any additional assets that are needed will need to be served directly from your [HTTP reverse proxy](#Service-configuration) (highly recommended).
+
+An example of customization of both the HTML templates and CSS markup can be found at [cweagans/semantic-laminar-theme](https://github.com/cweagans/semantic-laminar-theme).
 
 ---
 

--- a/UserManual.md
+++ b/UserManual.md
@@ -616,12 +616,6 @@ DESCRIPTION=Anything here will appear on the job page in the frontend <em>unesca
 
 Change `LAMINAR_TITLE` in `/etc/laminar.conf` to your preferred page title. Laminar must be restarted for this change to take effect.
 
-## Custom stylesheet
-
-If it exists, the file `/var/lib/laminar/custom/style.css` will be served by laminar and may be used to change the appearance of Laminar's WebUI.
-
-This directory is also a good place to add any extra assets needed for this customization, but note that in this case you will need to serve this directory directly from your [HTTP reverse proxy](#Service-configuration) (highly recommended).
-
 ## Custom HTML template
 
 If it exists, the file `/var/lib/laminar/custom/index.html` will be served by laminar instead of the default markup that is bundled into the Laminar binary. This file can be used to change any aspect of Laminar's WebUI, including adding custom menu links, stylesheets, or anything else. Any additional assets that are needed will need to be served directly from your [HTTP reverse proxy](#Service-configuration) (highly recommended).

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -248,7 +248,7 @@ kj::Promise<void> Http::request(kj::HttpMethod method, kj::StringPtr url, const 
     }
     // If there is custom html defined, serve it. Otherwise, the default html
     // will be served by the next block.
-    if(url == "/index.html" || url == "/") {
+    if(url == "/" || url == "/index.html" || url.startsWith("/jobs")) {
         responseHeaders.set(kj::HttpHeaderId::CONTENT_TYPE, "text/html; charset=utf-8");
         responseHeaders.add("Content-Transfer-Encoding", "binary");
         std::string html = laminar.getCustomIndexHtml();

--- a/src/http.h
+++ b/src/http.h
@@ -43,6 +43,9 @@ public:
     void notifyEvent(const char* data, std::string job = nullptr);
     void notifyLog(std::string job, uint run, std::string log_chunk, bool eot);
 
+    // Allows supplying a custom HTML template. Pass an empty string to use the default.
+    void setHtmlTemplate(std::string tmpl = std::string());
+
 private:
     virtual kj::Promise<void> request(kj::HttpMethod method, kj::StringPtr url, const kj::HttpHeaders& headers,
                                       kj::AsyncInputStream& requestBody, Response& response) override;

--- a/src/laminar.cpp
+++ b/src/laminar.cpp
@@ -796,3 +796,11 @@ std::string Laminar::getCustomCss() {
         return std::string();
     }
 }
+
+std::string Laminar::getCustomIndexHtml() {
+    KJ_IF_MAYBE(htmlFile, fsHome->tryOpenFile(kj::Path{"custom","index.html"})) {
+        return (*htmlFile)->readAllText().cStr();
+    } else {
+        return std::string();
+    }
+}

--- a/src/laminar.cpp
+++ b/src/laminar.cpp
@@ -113,12 +113,26 @@ Laminar::Laminar(Server &server, Settings settings) :
       .addPath((homePath/"cfg"/"jobs").toString(true).cStr())
       .addPath((homePath/"cfg").toString(true).cStr()); // for groups.conf
 
+    loadCustomizations();
+    srv.watchPaths([this]{
+        LLOG(INFO, "Reloading customizations");
+        loadCustomizations();
+    }).addPath((homePath/"custom").toString(true).cStr());
+
     srv.listenRpc(*rpc, settings.bind_rpc);
     srv.listenHttp(*http, settings.bind_http);
 
     // Load configuration, may be called again in response to an inotify event
     // that the configuration files have been modified
     loadConfiguration();
+}
+
+void Laminar::loadCustomizations() {
+    KJ_IF_MAYBE(templ, fsHome->tryOpenFile(kj::Path{"custom","index.html"})) {
+        http->setHtmlTemplate((*templ)->readAllText().cStr());
+    } else {
+        http->setHtmlTemplate();
+    }
 }
 
 uint Laminar::latestRun(std::string job) {
@@ -789,17 +803,15 @@ R"x(
     return true;
 }
 
+// TODO: deprecate
 std::string Laminar::getCustomCss() {
     KJ_IF_MAYBE(cssFile, fsHome->tryOpenFile(kj::Path{"custom","style.css"})) {
+        static bool warningShown = false;
+        if(!warningShown) {
+            LLOG(WARNING, "Custom CSS has been deprecated and will be removed from a future release. Use a custom HTML template instead.");
+            warningShown = true;
+        }
         return (*cssFile)->readAllText().cStr();
-    } else {
-        return std::string();
-    }
-}
-
-std::string Laminar::getCustomIndexHtml() {
-    KJ_IF_MAYBE(htmlFile, fsHome->tryOpenFile(kj::Path{"custom","index.html"})) {
-        return (*htmlFile)->readAllText().cStr();
     } else {
         return std::string();
     }

--- a/src/laminar.h
+++ b/src/laminar.h
@@ -95,6 +95,10 @@ public:
     // which handles this url.
     std::string getCustomCss();
 
+    // Fetches the content of $LAMINAR_HOME/custom/index.html or an empty
+    // string. This is used for custom template overrides.
+    std::string getCustomIndexHtml();
+
     // Aborts a single job
     bool abort(std::string job, uint buildNum);
 

--- a/src/laminar.h
+++ b/src/laminar.h
@@ -95,10 +95,6 @@ public:
     // which handles this url.
     std::string getCustomCss();
 
-    // Fetches the content of $LAMINAR_HOME/custom/index.html or an empty
-    // string. This is used for custom template overrides.
-    std::string getCustomIndexHtml();
-
     // Aborts a single job
     bool abort(std::string job, uint buildNum);
 
@@ -107,6 +103,7 @@ public:
 
 private:
     bool loadConfiguration();
+    void loadCustomizations();
     void assignNewJobs();
     bool tryStartRun(std::shared_ptr<Run> run, int queueIndex);
     void handleRunFinished(Run*);

--- a/src/resources.h
+++ b/src/resources.h
@@ -34,6 +34,9 @@ public:
     // type. Function returns false if no resource for the given path exists
     bool handleRequest(std::string path, const char** start, const char** end, const char** content_type);
 
+    // Allows providing a custom HTML template. Pass an empty string to use the default.
+    void setHtmlTemplate(std::string templ = std::string());
+
 private:
     struct Resource {
         const char* start;


### PR DESCRIPTION
Fixes https://github.com/ohwgiles/laminar/issues/112

This will allow anyone to completely override index.html and will make it easy to experiment with new UI designs for #57.

I plan to use this for two things:

1. Adding custom menu links to my Laminar instance
2. Continuing with the Semantic UI work that I was doing in #57 for use on my Laminar instance.

I'll probably go ahead and publish the Semantic UI work somewhere as a standalone "theme" for Laminar if this PR is merged.