### PR TITLE
WebUI refresh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,28 +62,12 @@ add_custom_command(OUTPUT laminar.capnp.c++ laminar.capnp.h
 
 # Zip and compile statically served resources
 generate_compressed_bins(${CMAKE_SOURCE_DIR}/src/resources index.html js/app.js
-    favicon.ico favicon-152.png icon.png)
+    css/app.css favicon.ico favicon-152.png icon.png)
 
 # The code that allows dynamic modifying of index.html requires knowing its original size
 add_custom_command(OUTPUT index_html_size.h
     COMMAND sh -c '( echo -n "\\#define INDEX_HTML_UNCOMPRESSED_SIZE " && wc -c < "${CMAKE_SOURCE_DIR}/src/resources/index.html" ) > index_html_size.h'
     DEPENDS src/resources/index.html)
-
-# Download 3rd-party frontend JS libs...
-file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/vue/2.3.4/vue.min.js
-        js/vue.min.js EXPECTED_MD5 ae2fca1cfa0e31377819b1b0ffef704c)
-file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/vue-router/2.7.0/vue-router.min.js
-        js/vue-router.min.js EXPECTED_MD5 5d3e35710dbe02de78c39e3e439b8d4e)
-file(DOWNLOAD https://raw.githubusercontent.com/drudru/ansi_up/v1.3.0/ansi_up.js
-        js/ansi_up.js EXPECTED_MD5 158566dc1ff8f2804de972f7e841e2f6)
-file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js
-        js/Chart.min.js EXPECTED_MD5 f6c8efa65711e0cbbc99ba72997ecd0e)
-file(DOWNLOAD https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css
-        css/bootstrap.min.css EXPECTED_MD5 5d5357cb3704e1f43a1f5bfed2aebf42)
-# ...and compile them
-generate_compressed_bins(${CMAKE_BINARY_DIR} js/vue-router.min.js js/vue.min.js
-    js/ansi_up.js js/Chart.min.js css/bootstrap.min.css)
-# (see resources.cpp where these are fetched)
 
 set(LAMINARD_CORE_SOURCES
     src/conf.cpp

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -42,12 +42,6 @@ Resources::Resources()
     INIT_RESOURCE("/favicon-152.png", favicon_152_png, CONTENT_TYPE_PNG);
     INIT_RESOURCE("/icon.png", icon_png, CONTENT_TYPE_PNG);
     INIT_RESOURCE("/js/app.js", js_app_js, CONTENT_TYPE_JS);
-    INIT_RESOURCE("/js/ansi_up.js", js_ansi_up_js, CONTENT_TYPE_JS);
-    INIT_RESOURCE("/js/vue.min.js", js_vue_min_js, CONTENT_TYPE_JS);
-    INIT_RESOURCE("/js/vue-router.min.js", js_vue_router_min_js, CONTENT_TYPE_JS);
-    INIT_RESOURCE("/js/ansi_up.js", js_ansi_up_js, CONTENT_TYPE_JS);
-    INIT_RESOURCE("/js/Chart.min.js", js_Chart_min_js, CONTENT_TYPE_JS);
-    INIT_RESOURCE("/css/bootstrap.min.css", css_bootstrap_min_css, CONTENT_TYPE_CSS);
 
     if(const char* baseUrl = getenv("LAMINAR_BASE_URL")) {
         // The administrator needs to customize the <base href>. Unfortunately this seems
@@ -110,4 +104,3 @@ bool Resources::handleRequest(std::string path, const char** start, const char**
 
     return false;
 }
-

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -42,6 +42,7 @@ Resources::Resources()
     INIT_RESOURCE("/favicon-152.png", favicon_152_png, CONTENT_TYPE_PNG);
     INIT_RESOURCE("/icon.png", icon_png, CONTENT_TYPE_PNG);
     INIT_RESOURCE("/js/app.js", js_app_js, CONTENT_TYPE_JS);
+    INIT_RESOURCE("/css/app.css", css_app_css, CONTENT_TYPE_CSS);
 
     if(const char* baseUrl = getenv("LAMINAR_BASE_URL")) {
         // The administrator needs to customize the <base href>. Unfortunately this seems

--- a/src/resources/css/app.css
+++ b/src/resources/css/app.css
@@ -1,41 +1,41 @@
 #app {
-  height: 100%;
+    height: 100%;
 }
 
 #app aside {
-  background-color: #eeeeee;
-  height: 100%;
+    background-color: #eeeeee;
+    height: 100%;
 }
 
 @media only screen and (min-width: 768px) {
-  #app .main.grid {
-      height: 100%;
-  }
+    #app .main.grid {
+        height: 100%;
+    }
 
-  #app .jobs.list {
-      -webkit-box-shadow: 3px 0px 5px 0px rgba(50, 50, 50, 0.25);
-      -moz-box-shadow:    3px 0px 5px 0px rgba(50, 50, 50, 0.25);
-      box-shadow:         3px 0px 5px 0px rgba(50, 50, 50, 0.25);
-  }
+    #app .jobs.list {
+        -webkit-box-shadow: 3px 0px 5px 0px rgba(50, 50, 50, 0.25);
+        -moz-box-shadow:    3px 0px 5px 0px rgba(50, 50, 50, 0.25);
+        box-shadow:         3px 0px 5px 0px rgba(50, 50, 50, 0.25);
+    }
 }
 
 #popup-connecting {
-  position: fixed;
-  bottom: 10px;
-  right: 10px;
-  padding: 20px;
+    position: fixed;
+    bottom: 10px;
+    right: 10px;
+    padding: 20px;
 }
 
 canvas {
- width: 100% !important;
- max-width: 800px;
- height: auto !important;
+    width: 100% !important;
+    max-width: 800px;
+    height: auto !important;
 }
 
 li.chart-overlay {
-  position: absolute;
-  display: inline-block;
-  background: white;
-  border: 1px solid lightgray;
-  padding: 3px;
+    position: absolute;
+    display: inline-block;
+    background: white;
+    border: 1px solid lightgray;
+    padding: 3px;
 } 

--- a/src/resources/css/app.css
+++ b/src/resources/css/app.css
@@ -1,0 +1,84 @@
+body, html { height: 100%; }
+.navbar { margin-bottom: 0; border-radius: 0; }
+.navbar-brand { margin: 0 -15px; padding: 7px 15px }
+.navbar-brand>img { display: inline; }
+a.navbar-btn { color: #9d9d9d; }
+a.navbar-btn.active { color: #fff; }
+a.navbar-btn:hover { color: #fff; text-decoration: none; }
+a.navbar-btn:focus { color: #fff; }
+.bell { margin: 8px 15px; color: #9d9d9d; }
+.bell:hover { text-decoration: none; color: #9d9d9d; cursor: pointer; }
+.bell.active { color: #333; }
+dt,dd { line-height: 2; }
+canvas {
+ width: 100% !important;
+ max-width: 800px;
+ height: auto !important;
+}
+.progress {
+ height: 10px;
+ margin-top: 5px;
+ margin-bottom: 0;
+}
+table#joblist tr:first-child td { border-top: 0; }
+#popup-connecting {
+  position: fixed;
+  background: white;
+  border: 1px solid #ddd;
+  bottom: 10px;
+  right: 10px;
+  padding: 20px;
+}
+/* status icons */
+span.status {
+  display: inline-block;
+  width: 1em;
+  text-align: center;
+  font-family: sans-serif;
+}
+span.success { color: forestgreen; }
+span.failed { color: firebrick; }
+span.aborted { color: indigo; }
+span.spin {
+  color: steelblue;
+  animation: 2s linear infinite spin;
+}
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+/* chart overlay */
+li.chart-overlay {
+  position: absolute;
+  display: inline-block;
+  background: white;
+  border: 1px solid lightgray;
+  padding: 3px;
+}
+/* sort indicators */
+a.sort {
+  position: relative;
+  margin-left: 7px;
+}
+a.sort:before, a.sort:after {
+  border: 4px solid transparent;
+  content: "";
+  position: absolute;
+  display: block;
+  height: 0;
+  width: 0;
+  right: 0;
+  top: 50%;
+}
+a.sort:before {
+  border-bottom-color: #ccc;
+  margin-top: -9px;
+}
+a.sort:after {
+  border-top-color: #ccc;
+  margin-top: 1px;
+}
+a.sort.dsc:after { border-top-color: #000; }
+a.sort.asc:before { border-bottom-color: #000; }
+a.sort:hover { text-decoration: none; cursor:pointer; }
+a.sort:not(.asc):hover:before { border-bottom-color: #777;  }
+a.sort:not(.dsc):hover:after { border-top-color: #777;  }

--- a/src/resources/css/app.css
+++ b/src/resources/css/app.css
@@ -1,84 +1,41 @@
-body, html { height: 100%; }
-.navbar { margin-bottom: 0; border-radius: 0; }
-.navbar-brand { margin: 0 -15px; padding: 7px 15px }
-.navbar-brand>img { display: inline; }
-a.navbar-btn { color: #9d9d9d; }
-a.navbar-btn.active { color: #fff; }
-a.navbar-btn:hover { color: #fff; text-decoration: none; }
-a.navbar-btn:focus { color: #fff; }
-.bell { margin: 8px 15px; color: #9d9d9d; }
-.bell:hover { text-decoration: none; color: #9d9d9d; cursor: pointer; }
-.bell.active { color: #333; }
-dt,dd { line-height: 2; }
+#app {
+  height: 100%;
+}
+
+#app aside {
+  background-color: #eeeeee;
+  height: 100%;
+}
+
+@media only screen and (min-width: 768px) {
+  #app .main.grid {
+      height: 100%;
+  }
+
+  #app .jobs.list {
+      -webkit-box-shadow: 3px 0px 5px 0px rgba(50, 50, 50, 0.25);
+      -moz-box-shadow:    3px 0px 5px 0px rgba(50, 50, 50, 0.25);
+      box-shadow:         3px 0px 5px 0px rgba(50, 50, 50, 0.25);
+  }
+}
+
+#popup-connecting {
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  padding: 20px;
+}
+
 canvas {
  width: 100% !important;
  max-width: 800px;
  height: auto !important;
 }
-.progress {
- height: 10px;
- margin-top: 5px;
- margin-bottom: 0;
-}
-table#joblist tr:first-child td { border-top: 0; }
-#popup-connecting {
-  position: fixed;
-  background: white;
-  border: 1px solid #ddd;
-  bottom: 10px;
-  right: 10px;
-  padding: 20px;
-}
-/* status icons */
-span.status {
-  display: inline-block;
-  width: 1em;
-  text-align: center;
-  font-family: sans-serif;
-}
-span.success { color: forestgreen; }
-span.failed { color: firebrick; }
-span.aborted { color: indigo; }
-span.spin {
-  color: steelblue;
-  animation: 2s linear infinite spin;
-}
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-/* chart overlay */
+
 li.chart-overlay {
   position: absolute;
   display: inline-block;
   background: white;
   border: 1px solid lightgray;
   padding: 3px;
-}
-/* sort indicators */
-a.sort {
-  position: relative;
-  margin-left: 7px;
-}
-a.sort:before, a.sort:after {
-  border: 4px solid transparent;
-  content: "";
-  position: absolute;
-  display: block;
-  height: 0;
-  width: 0;
-  right: 0;
-  top: 50%;
-}
-a.sort:before {
-  border-bottom-color: #ccc;
-  margin-top: -9px;
-}
-a.sort:after {
-  border-top-color: #ccc;
-  margin-top: 1px;
-}
-a.sort.dsc:after { border-top-color: #000; }
-a.sort.asc:before { border-bottom-color: #000; }
-a.sort:hover { text-decoration: none; cursor:pointer; }
-a.sort:not(.asc):hover:before { border-bottom-color: #777;  }
-a.sort:not(.dsc):hover:after { border-top-color: #777;  }
+} 

--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -13,7 +13,7 @@
  <script src="https://cdn.jsdelivr.net/npm/vue-router@3.1.6/dist/vue-router.min.js" integrity="sha256-B8zvQ+y1lIQkcm+EJyCis+7AgsnzaTCBAHgkrPFQr9A=" crossorigin="anonymous"></script>
  <script src="https://cdn.jsdelivr.net/npm/ansi_up@1.3.0/ansi_up.js" integrity="sha256-2UR0QYPMTIY0yP5S6ubBS7wFNKhn8uW7pV5E3LlvI6U=" crossorigin="anonymous"></script>
  <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>
- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.5/dist/css/bootstrap.min.css" integrity="sha256-MfvZlkHCEqatNoGiOXveE8FIwMzZg4W85qfrfIFBfYc=" crossorigin="anonymous">
+ <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css" integrity="sha256-UXesixbeLkB/UYxVTzuj/gg3+LMzgwAmg3zD+C4ZASQ=" crossorigin="anonymous">
  <link href="css/app.css" rel="stylesheet">
  <link href="custom/style.css" rel="stylesheet">
  <script src="js/app.js" defer></script>
@@ -240,14 +240,15 @@
  </div></template>
 
  <div id="app">
-  <nav class="navbar navbar-inverse">
-   <div>
-    <router-link to="/" class="navbar-brand"><img src="icon.png">{{title}}</router-link>
-    <router-link to="/jobs" class="btn navbar-btn pull-right">Jobs</router-link>
-   </div>
+    <nav class="ui left visible vertical inverted sidebar labeled icon menu">
+      <span class="item"><img class="icon" src="icon.png">{{title}}</span>
+      <router-link to="/" class="item"><i class="bar chart icon"></i>Status</router-link>
+      <router-link to="/jobs" class="item"><i class="tasks icon"></i>Jobs</router-link>
+      <a v-on:click="toggleNotifications(!notify)" v-show="supportsNotifications" class="item" :class="{'active':notify}" :title="(notify?'Disable':'Enable')+' notifications'"><i class="bell icon"></i>&#128276;</a>
   </nav>
-  <a v-on:click="toggleNotifications(!notify)" v-show="supportsNotifications" class="bell pull-right" :class="{'active':notify}" :title="(notify?'Disable':'Enable')+' notifications'">&#128276;</a>
+    <div class="pusher">
   <router-view></router-view>
+    </div>
   <div v-show="!connected" id="popup-connecting"><span class="status spin">⚙&#xfe0e;</span>&nbsp;Connecting...</div>
  </div>
 </body>

--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -325,6 +325,5 @@
             </div>
             <div v-show="!connected" id="popup-connecting" class="ui segment"><div class="ui basic loading segment"></div><p>Connecting</p></div>
         </div>
-        <script src="http://localhost:35729/livereload.js?snipver=1"></script>
     </body>
 </html>

--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -14,7 +14,6 @@
         <script src="https://cdn.jsdelivr.net/npm/ansi_up@1.3.0/ansi_up.js" integrity="sha256-2UR0QYPMTIY0yP5S6ubBS7wFNKhn8uW7pV5E3LlvI6U=" crossorigin="anonymous"></script>
         <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css" integrity="sha256-UXesixbeLkB/UYxVTzuj/gg3+LMzgwAmg3zD+C4ZASQ=" crossorigin="anonymous">
-        <link href="css/app.css" rel="stylesheet">
         <link href="custom/style.css" rel="stylesheet">
         <script src="js/app.js" defer></script>
     </head>
@@ -23,7 +22,7 @@
         <template id="home">
             <div class="ui stackable vertically padded grid">
                 <aside class="four wide column jobs list">
-                    <h3 class="ui header">Jobs</h3>
+                    <h2 class="ui header">Jobs</h2>
                     <div class="ui grey segment" v-for="job in jobsQueued">
                         <p><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link> queued</p>
                     </div>
@@ -139,143 +138,193 @@
             </div>
         </template>
 
-      <template id="jobs"><div>
-        <ol class="breadcrumb"><li><router-link to="/">Home</router-link></li><li class="active">Jobs</li></ol>
-        <div class="container-fluid"><div class="row">
-        <div class="col-xs-12">
-          <div class="pull-right">
-          <input class="form-control" id="jobFilter" v-model="search" placeholder="Filter...">
-          </div>
-          <ul class="nav nav-tabs">
-          <li v-show="ungrouped.length" :class="{'active':group==null}"><a href v-on:click.prevent="group = null">Ungrouped Jobs</a></li>
-          <li v-for="g in Object.keys(groups)" :class="{'active':g==group}"><a href v-on:click.prevent="group = g">{{g}}</a></li>
-          </ul>
-          <table class="table table-striped" id="joblist">
-          <tr   v-for="job in filteredJobs()">
-            <td><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link></td>
-            <td class="text-center"><span v-html="runIcon(job.result)"></span> <router-link :to="'/jobs/'+job.name+'/'+job.number">#{{job.number}}</router-link></td>
-            <td class="text-center">{{formatDate(job.started)}}</td>
-            <td class="text-center">{{formatDuration(job.started,job.completed)}}</td>
-          </tr>
-          </table>
-        </div>
-        </div></div>
-      </div></template>
-
-      <template id="job"><div>
-        <ol class="breadcrumb"><li><router-link to="/">Home</router-link></li><li><router-link to="/jobs">Jobs</router-link></li><li class="active">{{$route.params.name}}</li></ol></ol>
-        <div class="container-fluid">
-        <div class="row">
-          <div class="col-sm-5 col-md-6 col-lg-7">
-          <h3>{{$route.params.name}}</h3>
-          <div v-html="description"></div>
-          <dl class="dl-horizontal">
-          <dt>Last Successful Run</dt>
-          <dd><router-link v-if="lastSuccess" :to="'/jobs/'+$route.params.name+'/'+lastSuccess.number">#{{lastSuccess.number}}</router-link> {{lastSuccess?' - at '+formatDate(lastSuccess.started):'never'}}</dd>
-          <dt>Last Failed Run</dt>
-          <dd><router-link v-if="lastFailed" :to="'/jobs/'+$route.params.name+'/'+lastFailed.number">#{{lastFailed.number}}</router-link> {{lastFailed?' - at '+formatDate(lastFailed.started):'never'}}</dd>
-          </dl>
-          </div>
-          <div class="col-sm-7 col-md-6 col-lg-5">
-          <div class="panel panel-default">
-            <div class="panel-heading">Build time</div>
-            <div class="panel-body">
-            <canvas id="chartBt"></canvas>
+        <template id="jobs">
+            <main class="ui stackable vertically padded fourteen wide column">
+                <div class="ui basic segment masthead">
+                    <h2 class="ui header">Jobs</h2>
+                </div>
+                <div class="ui secondary pointing menu">
+                    <a v-show="ungrouped.length" :class="{'active':group==null}" v-on:click.prevent="group = null" class="item">Ungrouped jobs</a>
+                    <a v-for="g in Object.keys(groups)" :class="{'active':g==group}" href v-on:click.prevent="group = g" class="item">{{g}}</a>
+                    <div class="right menu">
+                        <div class="item">
+                            <div class="ui transparent icon input">
+                                <input id="jobFilter" v-model="search" type="text" placeholder="Filter...">
+                                <i class="search link icon"></i>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <table class="ui striped table" id="joblist">
+                    <thead>
+                        <tr>
+                            <th class="four wide">Job</th>
+                            <th>Last run</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-for="job in filteredJobs()">
+                            <td><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link></td>
+                            <td>
+                                <router-link :to="'/jobs/'+job.name+'/'+job.number">#{{job.number}}</router-link>: <span v-html="job.result ? job.result : 'pending'"></span><br />
+                                Started at {{formatDate(job.started)}} and ran for {{formatDuration(job.started,job.completed)}}
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
-          </div>
-          </div>
-        </div>
-        <div class="row"><div class="col-xs-12">
-          <table class="table table-striped">
-          <thead><tr>
-            <th><a class="sort" :class="(sort.field=='result'?sort.order:'')" v-on:click="do_sort('result')">&nbsp;</a></th>
-            <th>Run <a class="sort" :class="(sort.field=='number'?sort.order:'')" v-on:click="do_sort('number')">&nbsp;</a></th>
-            <th class="text-center">Started <a class="sort" :class="(sort.field=='started'?sort.order:'')" v-on:click="do_sort('started')">&nbsp;</a></th>
-            <th class="text-center">Duration <a class="sort" :class="(sort.field=='duration'?sort.order:'')" v-on:click="do_sort('duration')">&nbsp;</a></th>
-            <th class="text-center hidden-xs">Reason <a class="sort" :class="(sort.field=='reason'?sort.order:'')" v-on:click="do_sort('reason')">&nbsp;</a></th>
-          </tr></thead>
-          <tr v-show="nQueued">
-            <td colspan="5"><i>{{nQueued}} run(s) queued</i></td>
-          </tr>
-          <tr v-for="job in jobsRunning" track-by="$index">
-            <td style="width:1px"><span v-html="runIcon(job.result)"></span></td>
-            <td><router-link :to="'/jobs/'+$route.params.name+'/'+job.number">#{{job.number}}</router-link></td>
-            <td class="text-center">{{formatDate(job.started)}}</td>
-            <td class="text-center">{{formatDuration(job.started, job.completed)}}</td>
-            <td class="text-center hidden-xs">{{job.reason}}</td>
-          </tr>
-          <tr v-for="job in jobsRecent" track-by="$index">
-            <td style="width:1px"><span v-html="runIcon(job.result)"></span></td>
-            <td><router-link :to="'/jobs/'+$route.params.name+'/'+job.number">#{{job.number}}</router-link></td>
-            <td class="text-center">{{formatDate(job.started)}}</td>
-            <td class="text-center">{{formatDuration(job.started, job.completed)}}</td>
-            <td class="text-center hidden-xs">{{job.reason}}</td>
-          </tr>
-          </table>
-          <ul class="pagination pull-right">
-            <li><button class="btn btn-default" v-on:click="page_prev" :disabled="sort.page==0">&laquo;</button></li>
-            <li>Page {{sort.page+1}} of {{pages}}</li>
-            <li><button class="btn btn-default" v-on:click="page_next" :disabled="sort.page==pages-1">&raquo;</button></li>
-          </ul>
-        </div></div>
-        </div>
-      </div></template>
+        </template>
 
-      <template id="run"><div>
-        <ol class="breadcrumb"><li><router-link to="/">Home</router-link></li><li><router-link to="/jobs">Jobs</router-link></li><li><router-link :to="'/jobs/'+$route.params.name">{{$route.params.name}}</router-link></li><li class="active">#{{$route.params.number}}</li></ol></ol>
-        <div class="container-fluid">
-        <div class="row">
-          <div class="col-sm-5 col-md-6 col-lg-7">
-          <h3 style="float:left"><span v-html="runIcon(job.result)"></span> {{$route.params.name}} #{{$route.params.number}}</h3>
-          <nav class="pull-left">
-            <ul class="pagination" style="margin:15px 20px">
-            <li v-show="$route.params.number > 1"><router-link :to="'/jobs/'+$route.params.name+'/'+($route.params.number-1)">&laquo;</router-link></li>
-            <li v-show="latestNum > $route.params.number"><router-link :to="'/jobs/'+$route.params.name+'/'+(parseInt($route.params.number)+1)">&raquo;</router-link></li>
-            </ul>
-          </nav>
-          <div style="clear:both;"></div>
-          <dl class="dl-horizontal">
-            <dt>Reason</dt><dd>{{job.reason}}</dd>
-            <dt v-show="job.upstream.num > 0">Upstream</dt><dd v-show="job.upstream.num > 0"><router-link :to="'/jobs/'+job.upstream.name">{{job.upstream.name}}</router-link> <router-link :to="'/jobs/'+job.upstream.name+'/'+job.upstream.num">#{{job.upstream.num}}</router-link></li></dd>
-            <dt>Queued for</dt><dd>{{job.queued}}s</dd>
-            <dt>Started</dt><dd>{{formatDate(job.started)}}</dd>
-            <dt v-show="runComplete(job)">Completed</dt><dd v-show="job.completed">{{formatDate(job.completed)}}</dd>
-            <dt>Duration</dt><dd>{{formatDuration(job.started, job.completed)}}</dd>
-          </dl>
-          </div>
-          <div class="col-sm-7 col-md-6 col-lg-5">
-          <div class="progress" v-show="job.result == 'running'">
-            <div class="progress-bar  progress-bar-striped" :class="'progress-bar-'+(job.overtime?'warning':'info')" :class="job.etc?'':'active'" :style="{width:!job.etc?100:job.progress + '%'}"></div>
-          </div>
-          <div class="panel panel-default" v-show="job.artifacts.length">
-            <div class="panel-heading">Artifacts</div>
-            <div class="panel-body">
-            <ul class="list-unstyled" style="margin-bottom: 0">
-              <li v-for="art in job.artifacts"><a :href="art.url" target="_self">{{art.filename}}</a> [{{ art.size | iecFileSize }}]</li>
-            </ul>
-            </div>
-          </div>
-          </div>
-        </div>
-        <div class="row"><div class="col-xs-12">
-          <button type="button" class="btn btn-default btn-xs pull-right" :class="{'active':autoscroll}" v-on:click="autoscroll = !autoscroll" style="margin-top:10px">Autoscroll</button>
-          <h4>Console output</h4>
-          <pre v-html="log"></pre>
-        </div></div>
-        </div>
-      </div></template>
+        <template id="job">
+            <main class="ui stackable vertically padded fourteen wide column">
+                <div class="ui basic segment">
+                    <h2 class="ui header">
+                        Job: {{$route.params.name}}
+                    </h2>
+                    <router-link to="/jobs"><i class="angle left icon"></i>back to jobs list</router-link>
+                </div>
+                <div class="ui stackable padded two column grid">
+                    <div class="ui column seven wide">
+                        <h3 class="ui header">Information</h3>
+                        <div class="sub header" v-html="description"></div>
+                        <table class="ui table">
+                            <tr>
+                                <td>Last successful run</td>
+                                <td><router-link v-if="lastSuccess" :to="'/jobs/'+$route.params.name+'/'+lastSuccess.number">#{{lastSuccess.number}}</router-link> {{lastSuccess?' - at '+formatDate(lastSuccess.started):'never'}}</td>
+                            </tr>
+                            <tr>
+                                <td>Last failed run</td>
+                                <td><router-link v-if="lastFailed" :to="'/jobs/'+$route.params.name+'/'+lastFailed.number">#{{lastFailed.number}}</router-link> {{lastFailed?' - at '+formatDate(lastFailed.started):'never'}}</td>
+                            </tr>
+                        </table>
+                    </div>
+                    <div class="ui column seven wide">
+                        <h3 class="ui header">Build time</h3>
+                        <div><canvas id="chartBt"></canvas></div>
+                    </div>
+                </div>
+                <table class="ui striped table">
+                    <thead>
+                        <tr>
+                            <th class="three wide">Run</th>
+                            <th class="six wide">Duration</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-show="nQueued">
+                            <td colspan="5">{{nQueued}} more run(s) queued</td>
+                        </tr>
+                        <tr v-for="job in jobsRunning" track-by="$index">
+                            <td>
+                                <router-link :to="'/jobs/'+$route.params.name+'/'+job.number">#{{job.number}}</router-link><br>
+                                <span v-html="job.result ? job.result : 'pending'"></span>
+                            </td>
+                            <td>
+                                <div class="ui active small blue progress">
+                                    <div class="bar" :class="job.etc?'':'active'" :style="'width:'+(!job.etc?'100':job.progress)+'%'"></div>
+                                    <div class="label">Running for {{formatDuration(job.started, job.completed)}}</div>
+                                </div>
+                            </td>
+                        </tr>
+                        <tr v-for="job in jobsRecent" track-by="$index">
+                            <td>
+                                <router-link :to="'/jobs/'+$route.params.name+'/'+job.number">#{{job.number}}</router-link><br>
+                                <span v-html="job.result ? job.result : 'pending'"></span>
+                            </td>
+                            <td>
+                                Started: {{formatDate(job.started)}}<br>
+                                Ran for {{formatDuration(job.started,job.completed)}}
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <div class="ui pagination menu">
+                    <a class="item" v-on:click="page_prev" :class="sort.page==0 ? 'disabled' : ''"><i class="left angle icon"></i>Previous</a>
+                    <div class="item">
+                    Page {{sort.page+1}} of {{pages}}
+                    </div>
+                    <a class="item" v-on:click="page_next" :class="sort.page==pages-1 ? 'disabled' : ''"><i class="right angle icon"></i>Next</a>
+                </div>
+            </main>
+        </template>
+
+        <template id="run">
+            <main class="ui stackable vertically padded fourteen wide column">
+                <div class="ui basic segment">
+                    <h2 class="ui header">
+                        Job run: {{$route.params.name}} #{{$route.params.number}}
+                    </h2>
+                    <router-link :to="'/jobs/' + $route.params.name"><i class="angle left icon"></i>back to {{$route.params.name}} job list</router-link>
+                </div>
+
+                <div class="ui stackable padded two column grid">
+                    <div class="ui column four wide">
+                        <h3 class="ui header">Information</h3>
+                        <div class="ui pagination menu">
+                            <router-link class="item" v-show="$route.params.number > 1" :to="'/jobs/'+$route.params.name+'/'+($route.params.number-1)"><i class="left angle icon"></i>Previous run</router-link>
+                            <router-link class="item" v-show="latestNum > $route.params.number" :to="'/jobs/'+$route.params.name+'/'+(parseInt($route.params.number)+1)"><i class="right angle icon"></i>Next run</router-link>
+                        </div>
+                        <table class="ui table">
+                            <tr v-show="job.reason">
+                                <td>Reason</td>
+                                <td>{{job.reason}}</td>
+                            </tr>
+                            <tr v-show="job.upstream.num > 0">
+                                <td>Upstream</td>
+                                <td><router-link :to="'/jobs/'+job.upstream.name">{{job.upstream.name}}</router-link> <router-link :to="'/jobs/'+job.upstream.name+'/'+job.upstream.num">#{{job.upstream.num}}</router-link></td>
+                            </tr>
+                            <tr>
+                                <td>Queued for</td>
+                                <td>{{job.queued}}s</td>
+                            </tr>
+                            <tr>
+                                <td>Started</td>
+                                <td>{{formatDate(job.started)}}</td>
+                            </tr>
+                            <tr v-show="runComplete(job)">
+                                <td>Completed</td>
+                                <td>{{formatDate(job.completed)}}</td>
+                            </tr>
+                            <tr v-show="runComplete(job)">
+                                <td>Duration</td>
+                                <td>{{formatDuration(job.started, job.completed)}}</td>
+                            </tr>
+                            <tr v-show="!runComplete(job) && job.result == 'running'">
+                                <td>Progress</td>
+                                <td>
+                                    <div class="ui active small blue progress">
+                                        <div class="bar" :class="job.etc?'':'active'" :style="'width:'+(!job.etc?'100':job.progress)+'%'"></div>
+                                        <div class="label">Running for {{formatDuration(job.started, job.completed)}}</div>
+                                    </div>
+                                </td>
+                            </tr>
+                        </table>
+                        <div v-show="job.artifacts.length">
+                            <h3 class="ui header">Artifacts</h3>
+                            <ul class="list-unstyled" style="margin-bottom: 0">
+                                <li v-for="art in job.artifacts"><a :href="art.url" target="_self">{{art.filename}}</a> [{{ art.size | iecFileSize }}]</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="ui ten wide column">
+                        <h3 class="ui header">Console output</h4>
+                        <pre class="ui inverted segment" v-html="log"></pre>
+                    </div>
+                </div>
+            </main>
+        </template>
 
         <div id="app">
             <nav class="ui visible thin left sidebar inverted vertical labeled icon menu">
                 <span class="item"><img class="icon" src="icon.png">{{title}}</span>
-                <router-link to="/" class="item"><i class="bar chart icon"></i>Status</router-link>
-                <router-link to="/jobs" class="item"><i class="tasks icon"></i>Jobs</router-link>
-                <a v-on:click="toggleNotifications(!notify)" v-show="supportsNotifications" class="item" :title="(notify?'Disable':'Enable')+' notifications'"><i class="bell outline icon" :class="notify?'':'slash'"></i><span v-html="notify ? 'Disable' : 'Enable'"></span><br>notifications</a>
+                <router-link to="/" class="item" exact-active-class="active"><i class="bar chart icon"></i>Status</router-link>
+                <router-link to="/jobs" class="item" active-class="active"><i class="tasks icon"></i>Jobs</router-link>
             </nav>
             <div class="ui main stackable padded grid pusher">
                 <router-view></router-view>
             </div>
             <div v-show="!connected" id="popup-connecting" class="ui segment"><div class="ui basic loading segment"></div><p>Connecting</p></div>
         </div>
+        <script src="http://localhost:35729/livereload.js?snipver=1"></script>
     </body>
 </html>

--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -9,11 +9,12 @@
  <link rel="apple-touch-icon-precomposed" href="favicon-152.png">
  <link rel="icon" href="favicon.ico">
  <title>Laminar</title>
- <script src="js/vue.min.js"></script>
- <script src="js/vue-router.min.js"></script>
- <script src="js/ansi_up.js"></script>
- <script src="js/Chart.min.js"></script>
- <link href="css/bootstrap.min.css" rel="stylesheet">
+ <script src="https://cdn.jsdelivr.net/npm/ansi_up@1.3.0/ansi_up.js" integrity="sha256-2UR0QYPMTIY0yP5S6ubBS7wFNKhn8uW7pV5E3LlvI6U=" crossorigin="anonymous"></script>
+ <script src="https://cdn.jsdelivr.net/npm/vue@2.6.11/dist/vue.min.js" integrity="sha256-ngFW3UnAN0Tnm76mDuu7uUtYEcG3G5H1+zioJw3t+68=" crossorigin="anonymous"></script>
+ <script src="https://cdn.jsdelivr.net/npm/vue-router@3.1.6/dist/vue-router.min.js" integrity="sha256-B8zvQ+y1lIQkcm+EJyCis+7AgsnzaTCBAHgkrPFQr9A=" crossorigin="anonymous"></script>
+ <script src="https://cdn.jsdelivr.net/npm/ansi_up@1.3.0/ansi_up.js" integrity="sha256-2UR0QYPMTIY0yP5S6ubBS7wFNKhn8uW7pV5E3LlvI6U=" crossorigin="anonymous"></script>
+ <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>
+ <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.5/dist/css/bootstrap.min.css" integrity="sha256-MfvZlkHCEqatNoGiOXveE8FIwMzZg4W85qfrfIFBfYc=" crossorigin="anonymous">
  <link href="custom/style.css" rel="stylesheet">
  <script src="js/app.js" defer></script>
  <style>

--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -20,99 +20,124 @@
     </head>
     <body>
 
-      <template id="home"><div>
-        <ol class="breadcrumb"><li class="active">Home</li></ol>
-        <div class="container-fluid"><div class="row">
-        <div class="col-sm-5 col-md-4 col-lg-3 dash">
-          <table class="table table-bordered">
-          <tr v-for="job in jobsQueued">
-            <td><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link> <i>queued</i></td>
-          </tr>
-          <tr v-for="job in jobsRunning">
-            <td><span v-html="runIcon(job.result)"></span> <router-link :to="'/jobs/'+job.name">{{job.name}}</router-link> <router-link :to="'/jobs/'+job.name+'/'+job.number">#{{job.number}}</router-link>
-            <small class="pull-right">{{formatDuration(job.started, job.completed)}}</small>
-            <div class="progress">
-              <div class="progress-bar progress-bar-striped" :class="'progress-bar-'+(job.overtime?'warning':'info')" :class="job.etc?'':'active'" :style="'width:'+(!job.etc?'100':job.progress)+'%'"></div>
+        <template id="home">
+            <div class="ui stackable vertically padded grid">
+                <aside class="four wide column jobs list">
+                    <h3 class="ui header">Jobs</h3>
+                    <div class="ui grey segment" v-for="job in jobsQueued">
+                        <p><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link> queued</p>
+                    </div>
+                    <div class="ui blue segment" v-for="job in jobsRunning">
+                        <p><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link> <router-link :to="'/jobs/'+job.name+'/'+job.number">#{{job.number}}</router-link></p>
+                        <div class="ui active small blue progress">
+                            <div class="bar" :class="job.etc?'':'active'" :style="'width:'+(!job.etc?'100':job.progress)+'%'"></div>
+                            <div class="label">Running for {{formatDuration(job.started, job.completed)}}</div>
+                        </div>
+                    </div>
+                    <div v-for="job in jobsRecent" class="ui segment" :class="job.result == 'success' ? 'green' : ''" :class="job.result == 'failed' ? 'red' : ''" :class="job.result == 'aborted' ? 'red' : ''">
+                        <p>{{job.result | capitalize}}: <router-link :to="'/jobs/'+job.name">{{job.name}}</router-link> <router-link :to="'/jobs/'+job.name+'/'+job.number">#{{job.number}}</router-link></p>
+                        <p>{{formatDuration(job.started, job.completed)}} at {{formatDate(job.started)}}</p>
+                    </div>
+                </aside>
+                <main class="ten wide column">
+                    <div class="ui three column stackable grid">
+                        <div class="column">
+                            <div class="ui fluid card">
+                                <div class="image">
+                                    <canvas id="chartBpd"></canvas>
+                                </div>
+                                <div class="content">
+                                    <span class="header">Total runs per day this week</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="column">
+                            <div class="ui fluid card">
+                                <div class="image">
+                                    <canvas id="chartBpj"></canvas>
+                                </div>
+                                <div class="content">
+                                    <span class="header">Most runs per job in the last 24 hours</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="column">
+                            <div class="ui fluid card">
+                                <div class="image">
+                                    <canvas id="chartTpj"></canvas>
+                                </div>
+                                <div class="content">
+                                    <span class="header">Longest average run time per job this week</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="column">
+                            <div class="ui fluid card">
+                                <div class="image">
+                                    <canvas id="chartUtil"></canvas>
+                                </div>
+                                <div class="content">
+                                    <span class="header">Current executor utilization</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="column">
+                            <div class="ui fluid card">
+                                <div class="image">
+                                    <canvas id="chartResultChanges"></canvas>
+                                </div>
+                                <div class="content">
+                                    <span class="header">Regressions and recoveries</span>
+                                    <div class="description">
+                                        <ul v-for="job in resultChanged">
+                                            <li v-if="job.lastFailure>job.lastSuccess" :id="'rcd_'+job.name" class="chart-overlay"><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link>: <span v-html="runIcon('failed')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastFailure">#{{job.lastFailure}}</router-link> since <span v-html="runIcon('success')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastSuccess">#{{job.lastSuccess}}</router-link></li>
+                                            <li v-if="job.lastFailure<job.lastSuccess" :id="'rcd_'+job.name" class="chart-overlay"><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link>: <span v-html="runIcon('success')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastSuccess">#{{job.lastSuccess}}</router-link> since <span v-html="runIcon('failed')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastFailure">#{{job.lastFailure}}</router-link></li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="column">
+                            <div class="ui fluid card">
+                                <div class="image">
+                                    <canvas id="chartPassRates"></canvas>
+                                </div>
+                                <div class="content">
+                                    <span class="header">Low pass rates</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="column">
+                            <div class="ui fluid card">
+                                <div class="image">
+                                    <canvas id="chartBuildTimeChanges"></canvas>
+                                </div>
+                                <div class="content">
+                                    <span class="header">Run time changes</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="column">
+                            <div class="ui fluid card">
+                                <div class="image">
+                                    <canvas id="chartBuildTimeDist"></canvas>
+                                </div>
+                                <div class="content">
+                                    <span class="header">Average run time distribution</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </main>
             </div>
-            </td>
-          </tr>
-          <tr v-for="job in jobsRecent">
-            <td><span v-html="runIcon(job.result)"></span> <router-link :to="'/jobs/'+job.name">{{job.name}}</router-link> <router-link :to="'/jobs/'+job.name+'/'+job.number">#{{job.number}}</router-link><br><small>Took {{formatDuration(job.started, job.completed)}} at {{formatDate(job.started)}}</small></td>
-          </tr>
-          </table>
-        </div>
-        <div class="col-sm-7 col-md-8 col-lg-9"><div class="row">
-          <div class="col-md-6">
-          <div class="panel panel-default">
-            <div class="panel-heading">Total runs per day this week</div>
-            <div class="panel-body">
-            <canvas id="chartBpd"></canvas>
-            </div>
-          </div>
-          </div>
-          <div class="col-md-6">
-          <div class="panel panel-default">
-            <div class="panel-heading">Most runs per job in the last 24 hours</div>
-            <div class="panel-body" id="chartStatus">
-            <canvas id="chartBpj"></canvas>
-            </div>
-          </div>
-          </div></div><div class="row">
-          <div class="col-md-6">
-          <div class="panel panel-default">
-            <div class="panel-heading">Longest average run time per job this week</div>
-            <div class="panel-body">
-            <canvas id="chartTpj"></canvas>
-            </div>
-          </div>
-          </div>
-          <div class="col-md-6">
-          <div class="panel panel-default">
-            <div class="panel-heading">Current executor utilization</div>
-            <div class="panel-body">
-            <canvas id="chartUtil"></canvas>
-            </div>
-          </div>
-          </div></div><div class="row">
-          <div class="col-md-6">
-          <div class="panel panel-default">
-            <div class="panel-heading">Regressions and recoveries</div>
-            <div class="panel-body"><div style="position:relative">
-            <canvas id="chartResultChanges"></canvas>
-            <ul v-for="job in resultChanged">
-              <li v-if="job.lastFailure>job.lastSuccess" :id="'rcd_'+job.name" class="chart-overlay"><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link>: <span v-html="runIcon('failed')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastFailure">#{{job.lastFailure}}</router-link> since <span v-html="runIcon('success')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastSuccess">#{{job.lastSuccess}}</router-link></li>
-              <li v-if="job.lastFailure<job.lastSuccess" :id="'rcd_'+job.name" class="chart-overlay"><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link>: <span v-html="runIcon('success')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastSuccess">#{{job.lastSuccess}}</router-link> since <span v-html="runIcon('failed')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastFailure">#{{job.lastFailure}}</router-link></li>
-            </ul>
-            </div></div>
-          </div>
-          </div>
-          <div class="col-md-6">
-          <div class="panel panel-default">
-            <div class="panel-heading">Low pass rates</div>
-            <div class="panel-body">
-            <canvas id="chartPassRates"></canvas>
-            </div>
-          </div>
-          </div></div><div class="row">
-          <div class="col-md-6">
-          <div class="panel panel-default">
-            <div class="panel-heading">Run time changes</div>
-            <div class="panel-body">
-            <canvas id="chartBuildTimeChanges"></canvas>
-            </div>
-          </div>
-          </div>
-          <div class="col-md-6">
-          <div class="panel panel-default">
-            <div class="panel-heading">Average run time distribution</div>
-            <div class="panel-body">
-            <canvas id="chartBuildTimeDist"></canvas>
-            </div>
-          </div>
-          </div>
-        </div></div>
-        </div></div> 
-      </div></template>
+        </template>
 
       <template id="jobs"><div>
         <ol class="breadcrumb"><li><router-link to="/">Home</router-link></li><li class="active">Jobs</li></ol>
@@ -241,16 +266,16 @@
       </div></template>
 
         <div id="app">
-            <nav class="ui left visible vertical inverted sidebar labeled icon menu">
+            <nav class="ui visible thin left sidebar inverted vertical labeled icon menu">
                 <span class="item"><img class="icon" src="icon.png">{{title}}</span>
                 <router-link to="/" class="item"><i class="bar chart icon"></i>Status</router-link>
                 <router-link to="/jobs" class="item"><i class="tasks icon"></i>Jobs</router-link>
-                <a v-on:click="toggleNotifications(!notify)" v-show="supportsNotifications" class="item" :class="{'active':notify}" :title="(notify?'Disable':'Enable')+' notifications'"><i class="bell icon"></i>&#128276;</a>
+                <a v-on:click="toggleNotifications(!notify)" v-show="supportsNotifications" class="item" :title="(notify?'Disable':'Enable')+' notifications'"><i class="bell outline icon" :class="notify?'':'slash'"></i><span v-html="notify ? 'Disable' : 'Enable'"></span><br>notifications</a>
             </nav>
-            <div class="pusher">
+            <div class="ui main stackable padded grid pusher">
                 <router-view></router-view>
             </div>
-            <div v-show="!connected" id="popup-connecting"><span class="status spin">⚙&#xfe0e;</span>&nbsp;Connecting...</div>
+            <div v-show="!connected" id="popup-connecting" class="ui segment"><div class="ui basic loading segment"></div><p>Connecting</p></div>
         </div>
     </body>
 </html>

--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -9,7 +9,6 @@
  <link rel="apple-touch-icon-precomposed" href="favicon-152.png">
  <link rel="icon" href="favicon.ico">
  <title>Laminar</title>
- <script src="https://cdn.jsdelivr.net/npm/ansi_up@1.3.0/ansi_up.js" integrity="sha256-2UR0QYPMTIY0yP5S6ubBS7wFNKhn8uW7pV5E3LlvI6U=" crossorigin="anonymous"></script>
  <script src="https://cdn.jsdelivr.net/npm/vue@2.6.11/dist/vue.min.js" integrity="sha256-ngFW3UnAN0Tnm76mDuu7uUtYEcG3G5H1+zioJw3t+68=" crossorigin="anonymous"></script>
  <script src="https://cdn.jsdelivr.net/npm/vue-router@3.1.6/dist/vue-router.min.js" integrity="sha256-B8zvQ+y1lIQkcm+EJyCis+7AgsnzaTCBAHgkrPFQr9A=" crossorigin="anonymous"></script>
  <script src="https://cdn.jsdelivr.net/npm/ansi_up@1.3.0/ansi_up.js" integrity="sha256-2UR0QYPMTIY0yP5S6ubBS7wFNKhn8uW7pV5E3LlvI6U=" crossorigin="anonymous"></script>

--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -15,95 +15,9 @@
  <script src="https://cdn.jsdelivr.net/npm/ansi_up@1.3.0/ansi_up.js" integrity="sha256-2UR0QYPMTIY0yP5S6ubBS7wFNKhn8uW7pV5E3LlvI6U=" crossorigin="anonymous"></script>
  <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>
  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.5/dist/css/bootstrap.min.css" integrity="sha256-MfvZlkHCEqatNoGiOXveE8FIwMzZg4W85qfrfIFBfYc=" crossorigin="anonymous">
+ <link href="css/app.css" rel="stylesheet">
  <link href="custom/style.css" rel="stylesheet">
  <script src="js/app.js" defer></script>
- <style>
-  body, html { height: 100%; }
-  .navbar { margin-bottom: 0; border-radius: 0; }
-  .navbar-brand { margin: 0 -15px; padding: 7px 15px }
-  .navbar-brand>img { display: inline; }
-  a.navbar-btn { color: #9d9d9d; }
-  a.navbar-btn.active { color: #fff; }
-  a.navbar-btn:hover { color: #fff; text-decoration: none; }
-  a.navbar-btn:focus { color: #fff; }
-  .bell { margin: 8px 15px; color: #9d9d9d; }
-  .bell:hover { text-decoration: none; color: #9d9d9d; cursor: pointer; }
-  .bell.active { color: #333; }
-  dt,dd { line-height: 2; }
-  canvas {
-   width: 100% !important;
-   max-width: 800px;
-   height: auto !important;
-  }
-  .progress {
-   height: 10px;
-   margin-top: 5px;
-   margin-bottom: 0;
-  }
-  table#joblist tr:first-child td { border-top: 0; }
-  #popup-connecting {
-    position: fixed;
-    background: white;
-    border: 1px solid #ddd;
-    bottom: 10px;
-    right: 10px;
-    padding: 20px;
-  }
-  /* status icons */
-  span.status {
-    display: inline-block;
-    width: 1em;
-    text-align: center;
-    font-family: sans-serif;
-  }
-  span.success { color: forestgreen; }
-  span.failed { color: firebrick; }
-  span.aborted { color: indigo; }
-  span.spin {
-    color: steelblue;
-    animation: 2s linear infinite spin;
-  }
-  @keyframes spin {
-    to { transform: rotate(360deg); }
-  }
-  /* chart overlay */
-  li.chart-overlay {
-    position: absolute;
-    display: inline-block;
-    background: white;
-    border: 1px solid lightgray;
-    padding: 3px;
-  }
-  /* sort indicators */
-  a.sort {
-    position: relative;
-    margin-left: 7px;
-  }
-  a.sort:before, a.sort:after {
-    border: 4px solid transparent;
-    content: "";
-    position: absolute;
-    display: block;
-    height: 0;
-    width: 0;
-    right: 0;
-    top: 50%;
-  }
-  a.sort:before {
-    border-bottom-color: #ccc;
-    margin-top: -9px;
-  }
-  a.sort:after {
-    border-top-color: #ccc;
-    margin-top: 1px;
-  }
-  a.sort.dsc:after { border-top-color: #000; }
-  a.sort.asc:before { border-bottom-color: #000; }
-  a.sort:hover { text-decoration: none; cursor:pointer; }
-  a.sort:not(.asc):hover:before { border-bottom-color: #777;  }
-  a.sort:not(.dsc):hover:after { border-top-color: #777;  }
-
- </style>
 </head>
 <body>
  <template id="home"><div>
@@ -339,4 +253,3 @@
  </div>
 </body>
 </html>
-

--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -1,255 +1,256 @@
 <!doctype html>
 <html>
-<head>
- <base href="/">
- <meta charset="utf-8">
- <meta http-equiv="X-UA-Compatible" content="IE=edge">
- <meta name="viewport" content="width=device-width, initial-scale=1">
- <meta name="apple-mobile-web-app-capable" content="yes" />
- <link rel="apple-touch-icon-precomposed" href="favicon-152.png">
- <link rel="icon" href="favicon.ico">
- <title>Laminar</title>
- <script src="https://cdn.jsdelivr.net/npm/vue@2.6.11/dist/vue.min.js" integrity="sha256-ngFW3UnAN0Tnm76mDuu7uUtYEcG3G5H1+zioJw3t+68=" crossorigin="anonymous"></script>
- <script src="https://cdn.jsdelivr.net/npm/vue-router@3.1.6/dist/vue-router.min.js" integrity="sha256-B8zvQ+y1lIQkcm+EJyCis+7AgsnzaTCBAHgkrPFQr9A=" crossorigin="anonymous"></script>
- <script src="https://cdn.jsdelivr.net/npm/ansi_up@1.3.0/ansi_up.js" integrity="sha256-2UR0QYPMTIY0yP5S6ubBS7wFNKhn8uW7pV5E3LlvI6U=" crossorigin="anonymous"></script>
- <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>
- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css" integrity="sha256-UXesixbeLkB/UYxVTzuj/gg3+LMzgwAmg3zD+C4ZASQ=" crossorigin="anonymous">
- <link href="css/app.css" rel="stylesheet">
- <link href="custom/style.css" rel="stylesheet">
- <script src="js/app.js" defer></script>
-</head>
-<body>
- <template id="home"><div>
-  <ol class="breadcrumb"><li class="active">Home</li></ol>
-  <div class="container-fluid"><div class="row">
-   <div class="col-sm-5 col-md-4 col-lg-3 dash">
-    <table class="table table-bordered">
-     <tr v-for="job in jobsQueued">
-      <td><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link> <i>queued</i></td>
-     </tr>
-     <tr v-for="job in jobsRunning">
-      <td><span v-html="runIcon(job.result)"></span> <router-link :to="'/jobs/'+job.name">{{job.name}}</router-link> <router-link :to="'/jobs/'+job.name+'/'+job.number">#{{job.number}}</router-link>
-       <small class="pull-right">{{formatDuration(job.started, job.completed)}}</small>
-       <div class="progress">
-         <div class="progress-bar progress-bar-striped" :class="'progress-bar-'+(job.overtime?'warning':'info')" :class="job.etc?'':'active'" :style="'width:'+(!job.etc?'100':job.progress)+'%'"></div>
-       </div>
-      </td>
-     </tr>
-     <tr v-for="job in jobsRecent">
-      <td><span v-html="runIcon(job.result)"></span> <router-link :to="'/jobs/'+job.name">{{job.name}}</router-link> <router-link :to="'/jobs/'+job.name+'/'+job.number">#{{job.number}}</router-link><br><small>Took {{formatDuration(job.started, job.completed)}} at {{formatDate(job.started)}}</small></td>
-     </tr>
-    </table>
-   </div>
-   <div class="col-sm-7 col-md-8 col-lg-9"><div class="row">
-    <div class="col-md-6">
-     <div class="panel panel-default">
-      <div class="panel-heading">Total runs per day this week</div>
-      <div class="panel-body">
-       <canvas id="chartBpd"></canvas>
-      </div>
-     </div>
-    </div>
-    <div class="col-md-6">
-     <div class="panel panel-default">
-      <div class="panel-heading">Most runs per job in the last 24 hours</div>
-      <div class="panel-body" id="chartStatus">
-       <canvas id="chartBpj"></canvas>
-      </div>
-     </div>
-    </div></div><div class="row">
-    <div class="col-md-6">
-     <div class="panel panel-default">
-      <div class="panel-heading">Longest average run time per job this week</div>
-      <div class="panel-body">
-       <canvas id="chartTpj"></canvas>
-      </div>
-     </div>
-    </div>
-    <div class="col-md-6">
-     <div class="panel panel-default">
-      <div class="panel-heading">Current executor utilization</div>
-      <div class="panel-body">
-       <canvas id="chartUtil"></canvas>
-      </div>
-     </div>
-    </div></div><div class="row">
-    <div class="col-md-6">
-     <div class="panel panel-default">
-      <div class="panel-heading">Regressions and recoveries</div>
-      <div class="panel-body"><div style="position:relative">
-       <canvas id="chartResultChanges"></canvas>
-       <ul v-for="job in resultChanged">
-         <li v-if="job.lastFailure>job.lastSuccess" :id="'rcd_'+job.name" class="chart-overlay"><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link>: <span v-html="runIcon('failed')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastFailure">#{{job.lastFailure}}</router-link> since <span v-html="runIcon('success')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastSuccess">#{{job.lastSuccess}}</router-link></li>
-         <li v-if="job.lastFailure<job.lastSuccess" :id="'rcd_'+job.name" class="chart-overlay"><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link>: <span v-html="runIcon('success')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastSuccess">#{{job.lastSuccess}}</router-link> since <span v-html="runIcon('failed')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastFailure">#{{job.lastFailure}}</router-link></li>
-       </ul>
-      </div></div>
-     </div>
-    </div>
-    <div class="col-md-6">
-     <div class="panel panel-default">
-      <div class="panel-heading">Low pass rates</div>
-      <div class="panel-body">
-       <canvas id="chartPassRates"></canvas>
-      </div>
-     </div>
-    </div></div><div class="row">
-    <div class="col-md-6">
-     <div class="panel panel-default">
-      <div class="panel-heading">Run time changes</div>
-      <div class="panel-body">
-       <canvas id="chartBuildTimeChanges"></canvas>
-      </div>
-     </div>
-    </div>
-    <div class="col-md-6">
-     <div class="panel panel-default">
-      <div class="panel-heading">Average run time distribution</div>
-      <div class="panel-body">
-       <canvas id="chartBuildTimeDist"></canvas>
-      </div>
-     </div>
-    </div>
-   </div></div>
-  </div></div> 
- </div></template>
- 
- <template id="jobs"><div>
-  <ol class="breadcrumb"><li><router-link to="/">Home</router-link></li><li class="active">Jobs</li></ol>
-  <div class="container-fluid"><div class="row">
-   <div class="col-xs-12">
-    <div class="pull-right">
-     <input class="form-control" id="jobFilter" v-model="search" placeholder="Filter...">
-    </div>
-    <ul class="nav nav-tabs">
-     <li v-show="ungrouped.length" :class="{'active':group==null}"><a href v-on:click.prevent="group = null">Ungrouped Jobs</a></li>
-     <li v-for="g in Object.keys(groups)" :class="{'active':g==group}"><a href v-on:click.prevent="group = g">{{g}}</a></li>
-    </ul>
-    <table class="table table-striped" id="joblist">
-     <tr   v-for="job in filteredJobs()">
-      <td><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link></td>
-      <td class="text-center"><span v-html="runIcon(job.result)"></span> <router-link :to="'/jobs/'+job.name+'/'+job.number">#{{job.number}}</router-link></td>
-      <td class="text-center">{{formatDate(job.started)}}</td>
-      <td class="text-center">{{formatDuration(job.started,job.completed)}}</td>
-     </tr>
-    </table>
-   </div>
-  </div></div>
- </div></template>
- 
- <template id="job"><div>
-  <ol class="breadcrumb"><li><router-link to="/">Home</router-link></li><li><router-link to="/jobs">Jobs</router-link></li><li class="active">{{$route.params.name}}</li></ol></ol>
-  <div class="container-fluid">
-   <div class="row">
-    <div class="col-sm-5 col-md-6 col-lg-7">
-    <h3>{{$route.params.name}}</h3>
-    <div v-html="description"></div>
-    <dl class="dl-horizontal">
-     <dt>Last Successful Run</dt>
-     <dd><router-link v-if="lastSuccess" :to="'/jobs/'+$route.params.name+'/'+lastSuccess.number">#{{lastSuccess.number}}</router-link> {{lastSuccess?' - at '+formatDate(lastSuccess.started):'never'}}</dd>
-     <dt>Last Failed Run</dt>
-     <dd><router-link v-if="lastFailed" :to="'/jobs/'+$route.params.name+'/'+lastFailed.number">#{{lastFailed.number}}</router-link> {{lastFailed?' - at '+formatDate(lastFailed.started):'never'}}</dd>
-    </dl>
-    </div>
-    <div class="col-sm-7 col-md-6 col-lg-5">
-    <div class="panel panel-default">
-      <div class="panel-heading">Build time</div>
-      <div class="panel-body">
-      <canvas id="chartBt"></canvas>
-      </div>
-    </div>
-    </div>
-   </div>
-   <div class="row"><div class="col-xs-12">
-    <table class="table table-striped">
-     <thead><tr>
-      <th><a class="sort" :class="(sort.field=='result'?sort.order:'')" v-on:click="do_sort('result')">&nbsp;</a></th>
-      <th>Run <a class="sort" :class="(sort.field=='number'?sort.order:'')" v-on:click="do_sort('number')">&nbsp;</a></th>
-      <th class="text-center">Started <a class="sort" :class="(sort.field=='started'?sort.order:'')" v-on:click="do_sort('started')">&nbsp;</a></th>
-      <th class="text-center">Duration <a class="sort" :class="(sort.field=='duration'?sort.order:'')" v-on:click="do_sort('duration')">&nbsp;</a></th>
-      <th class="text-center hidden-xs">Reason <a class="sort" :class="(sort.field=='reason'?sort.order:'')" v-on:click="do_sort('reason')">&nbsp;</a></th>
-     </tr></thead>
-     <tr v-show="nQueued">
-      <td colspan="5"><i>{{nQueued}} run(s) queued</i></td>
-     </tr>
-     <tr v-for="job in jobsRunning" track-by="$index">
-      <td style="width:1px"><span v-html="runIcon(job.result)"></span></td>
-      <td><router-link :to="'/jobs/'+$route.params.name+'/'+job.number">#{{job.number}}</router-link></td>
-      <td class="text-center">{{formatDate(job.started)}}</td>
-      <td class="text-center">{{formatDuration(job.started, job.completed)}}</td>
-      <td class="text-center hidden-xs">{{job.reason}}</td>
-     </tr>
-     <tr v-for="job in jobsRecent" track-by="$index">
-      <td style="width:1px"><span v-html="runIcon(job.result)"></span></td>
-      <td><router-link :to="'/jobs/'+$route.params.name+'/'+job.number">#{{job.number}}</router-link></td>
-      <td class="text-center">{{formatDate(job.started)}}</td>
-      <td class="text-center">{{formatDuration(job.started, job.completed)}}</td>
-      <td class="text-center hidden-xs">{{job.reason}}</td>
-     </tr>
-    </table>
-    <ul class="pagination pull-right">
-      <li><button class="btn btn-default" v-on:click="page_prev" :disabled="sort.page==0">&laquo;</button></li>
-      <li>Page {{sort.page+1}} of {{pages}}</li>
-      <li><button class="btn btn-default" v-on:click="page_next" :disabled="sort.page==pages-1">&raquo;</button></li>
-    </ul>
-   </div></div>
-  </div>
- </div></template>
- 
- <template id="run"><div>
-  <ol class="breadcrumb"><li><router-link to="/">Home</router-link></li><li><router-link to="/jobs">Jobs</router-link></li><li><router-link :to="'/jobs/'+$route.params.name">{{$route.params.name}}</router-link></li><li class="active">#{{$route.params.number}}</li></ol></ol>
-  <div class="container-fluid">
-   <div class="row">
-    <div class="col-sm-5 col-md-6 col-lg-7">
-     <h3 style="float:left"><span v-html="runIcon(job.result)"></span> {{$route.params.name}} #{{$route.params.number}}</h3>
-     <nav class="pull-left">
-      <ul class="pagination" style="margin:15px 20px">
-       <li v-show="$route.params.number > 1"><router-link :to="'/jobs/'+$route.params.name+'/'+($route.params.number-1)">&laquo;</router-link></li>
-       <li v-show="latestNum > $route.params.number"><router-link :to="'/jobs/'+$route.params.name+'/'+(parseInt($route.params.number)+1)">&raquo;</router-link></li>
-      </ul>
-     </nav>
-     <div style="clear:both;"></div>
-     <dl class="dl-horizontal">
-      <dt>Reason</dt><dd>{{job.reason}}</dd>
-      <dt v-show="job.upstream.num > 0">Upstream</dt><dd v-show="job.upstream.num > 0"><router-link :to="'/jobs/'+job.upstream.name">{{job.upstream.name}}</router-link> <router-link :to="'/jobs/'+job.upstream.name+'/'+job.upstream.num">#{{job.upstream.num}}</router-link></li></dd>
-      <dt>Queued for</dt><dd>{{job.queued}}s</dd>
-      <dt>Started</dt><dd>{{formatDate(job.started)}}</dd>
-      <dt v-show="runComplete(job)">Completed</dt><dd v-show="job.completed">{{formatDate(job.completed)}}</dd>
-      <dt>Duration</dt><dd>{{formatDuration(job.started, job.completed)}}</dd>
-     </dl>
-    </div>
-    <div class="col-sm-7 col-md-6 col-lg-5">
-     <div class="progress" v-show="job.result == 'running'">
-      <div class="progress-bar  progress-bar-striped" :class="'progress-bar-'+(job.overtime?'warning':'info')" :class="job.etc?'':'active'" :style="{width:!job.etc?100:job.progress + '%'}"></div>
-     </div>
-     <div class="panel panel-default" v-show="job.artifacts.length">
-      <div class="panel-heading">Artifacts</div>
-      <div class="panel-body">
-       <ul class="list-unstyled" style="margin-bottom: 0">
-        <li v-for="art in job.artifacts"><a :href="art.url" target="_self">{{art.filename}}</a> [{{ art.size | iecFileSize }}]</li>
-       </ul>
-      </div>
-     </div>
-    </div>
-   </div>
-   <div class="row"><div class="col-xs-12">
-    <button type="button" class="btn btn-default btn-xs pull-right" :class="{'active':autoscroll}" v-on:click="autoscroll = !autoscroll" style="margin-top:10px">Autoscroll</button>
-    <h4>Console output</h4>
-    <pre v-html="log"></pre>
-   </div></div>
-  </div>
- </div></template>
+    <head>
+        <base href="/">
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <link rel="apple-touch-icon-precomposed" href="favicon-152.png">
+        <link rel="icon" href="favicon.ico">
+        <title>Laminar</title>
+        <script src="https://cdn.jsdelivr.net/npm/vue@2.6.11/dist/vue.min.js" integrity="sha256-ngFW3UnAN0Tnm76mDuu7uUtYEcG3G5H1+zioJw3t+68=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/vue-router@3.1.6/dist/vue-router.min.js" integrity="sha256-B8zvQ+y1lIQkcm+EJyCis+7AgsnzaTCBAHgkrPFQr9A=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/ansi_up@1.3.0/ansi_up.js" integrity="sha256-2UR0QYPMTIY0yP5S6ubBS7wFNKhn8uW7pV5E3LlvI6U=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css" integrity="sha256-UXesixbeLkB/UYxVTzuj/gg3+LMzgwAmg3zD+C4ZASQ=" crossorigin="anonymous">
+        <link href="css/app.css" rel="stylesheet">
+        <link href="custom/style.css" rel="stylesheet">
+        <script src="js/app.js" defer></script>
+    </head>
+    <body>
 
- <div id="app">
-    <nav class="ui left visible vertical inverted sidebar labeled icon menu">
-      <span class="item"><img class="icon" src="icon.png">{{title}}</span>
-      <router-link to="/" class="item"><i class="bar chart icon"></i>Status</router-link>
-      <router-link to="/jobs" class="item"><i class="tasks icon"></i>Jobs</router-link>
-      <a v-on:click="toggleNotifications(!notify)" v-show="supportsNotifications" class="item" :class="{'active':notify}" :title="(notify?'Disable':'Enable')+' notifications'"><i class="bell icon"></i>&#128276;</a>
-  </nav>
-    <div class="pusher">
-  <router-view></router-view>
-    </div>
-  <div v-show="!connected" id="popup-connecting"><span class="status spin">⚙&#xfe0e;</span>&nbsp;Connecting...</div>
- </div>
-</body>
+      <template id="home"><div>
+        <ol class="breadcrumb"><li class="active">Home</li></ol>
+        <div class="container-fluid"><div class="row">
+        <div class="col-sm-5 col-md-4 col-lg-3 dash">
+          <table class="table table-bordered">
+          <tr v-for="job in jobsQueued">
+            <td><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link> <i>queued</i></td>
+          </tr>
+          <tr v-for="job in jobsRunning">
+            <td><span v-html="runIcon(job.result)"></span> <router-link :to="'/jobs/'+job.name">{{job.name}}</router-link> <router-link :to="'/jobs/'+job.name+'/'+job.number">#{{job.number}}</router-link>
+            <small class="pull-right">{{formatDuration(job.started, job.completed)}}</small>
+            <div class="progress">
+              <div class="progress-bar progress-bar-striped" :class="'progress-bar-'+(job.overtime?'warning':'info')" :class="job.etc?'':'active'" :style="'width:'+(!job.etc?'100':job.progress)+'%'"></div>
+            </div>
+            </td>
+          </tr>
+          <tr v-for="job in jobsRecent">
+            <td><span v-html="runIcon(job.result)"></span> <router-link :to="'/jobs/'+job.name">{{job.name}}</router-link> <router-link :to="'/jobs/'+job.name+'/'+job.number">#{{job.number}}</router-link><br><small>Took {{formatDuration(job.started, job.completed)}} at {{formatDate(job.started)}}</small></td>
+          </tr>
+          </table>
+        </div>
+        <div class="col-sm-7 col-md-8 col-lg-9"><div class="row">
+          <div class="col-md-6">
+          <div class="panel panel-default">
+            <div class="panel-heading">Total runs per day this week</div>
+            <div class="panel-body">
+            <canvas id="chartBpd"></canvas>
+            </div>
+          </div>
+          </div>
+          <div class="col-md-6">
+          <div class="panel panel-default">
+            <div class="panel-heading">Most runs per job in the last 24 hours</div>
+            <div class="panel-body" id="chartStatus">
+            <canvas id="chartBpj"></canvas>
+            </div>
+          </div>
+          </div></div><div class="row">
+          <div class="col-md-6">
+          <div class="panel panel-default">
+            <div class="panel-heading">Longest average run time per job this week</div>
+            <div class="panel-body">
+            <canvas id="chartTpj"></canvas>
+            </div>
+          </div>
+          </div>
+          <div class="col-md-6">
+          <div class="panel panel-default">
+            <div class="panel-heading">Current executor utilization</div>
+            <div class="panel-body">
+            <canvas id="chartUtil"></canvas>
+            </div>
+          </div>
+          </div></div><div class="row">
+          <div class="col-md-6">
+          <div class="panel panel-default">
+            <div class="panel-heading">Regressions and recoveries</div>
+            <div class="panel-body"><div style="position:relative">
+            <canvas id="chartResultChanges"></canvas>
+            <ul v-for="job in resultChanged">
+              <li v-if="job.lastFailure>job.lastSuccess" :id="'rcd_'+job.name" class="chart-overlay"><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link>: <span v-html="runIcon('failed')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastFailure">#{{job.lastFailure}}</router-link> since <span v-html="runIcon('success')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastSuccess">#{{job.lastSuccess}}</router-link></li>
+              <li v-if="job.lastFailure<job.lastSuccess" :id="'rcd_'+job.name" class="chart-overlay"><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link>: <span v-html="runIcon('success')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastSuccess">#{{job.lastSuccess}}</router-link> since <span v-html="runIcon('failed')"></span> <router-link :to="'/jobs/'+job.name+'/'+job.lastFailure">#{{job.lastFailure}}</router-link></li>
+            </ul>
+            </div></div>
+          </div>
+          </div>
+          <div class="col-md-6">
+          <div class="panel panel-default">
+            <div class="panel-heading">Low pass rates</div>
+            <div class="panel-body">
+            <canvas id="chartPassRates"></canvas>
+            </div>
+          </div>
+          </div></div><div class="row">
+          <div class="col-md-6">
+          <div class="panel panel-default">
+            <div class="panel-heading">Run time changes</div>
+            <div class="panel-body">
+            <canvas id="chartBuildTimeChanges"></canvas>
+            </div>
+          </div>
+          </div>
+          <div class="col-md-6">
+          <div class="panel panel-default">
+            <div class="panel-heading">Average run time distribution</div>
+            <div class="panel-body">
+            <canvas id="chartBuildTimeDist"></canvas>
+            </div>
+          </div>
+          </div>
+        </div></div>
+        </div></div> 
+      </div></template>
+
+      <template id="jobs"><div>
+        <ol class="breadcrumb"><li><router-link to="/">Home</router-link></li><li class="active">Jobs</li></ol>
+        <div class="container-fluid"><div class="row">
+        <div class="col-xs-12">
+          <div class="pull-right">
+          <input class="form-control" id="jobFilter" v-model="search" placeholder="Filter...">
+          </div>
+          <ul class="nav nav-tabs">
+          <li v-show="ungrouped.length" :class="{'active':group==null}"><a href v-on:click.prevent="group = null">Ungrouped Jobs</a></li>
+          <li v-for="g in Object.keys(groups)" :class="{'active':g==group}"><a href v-on:click.prevent="group = g">{{g}}</a></li>
+          </ul>
+          <table class="table table-striped" id="joblist">
+          <tr   v-for="job in filteredJobs()">
+            <td><router-link :to="'/jobs/'+job.name">{{job.name}}</router-link></td>
+            <td class="text-center"><span v-html="runIcon(job.result)"></span> <router-link :to="'/jobs/'+job.name+'/'+job.number">#{{job.number}}</router-link></td>
+            <td class="text-center">{{formatDate(job.started)}}</td>
+            <td class="text-center">{{formatDuration(job.started,job.completed)}}</td>
+          </tr>
+          </table>
+        </div>
+        </div></div>
+      </div></template>
+
+      <template id="job"><div>
+        <ol class="breadcrumb"><li><router-link to="/">Home</router-link></li><li><router-link to="/jobs">Jobs</router-link></li><li class="active">{{$route.params.name}}</li></ol></ol>
+        <div class="container-fluid">
+        <div class="row">
+          <div class="col-sm-5 col-md-6 col-lg-7">
+          <h3>{{$route.params.name}}</h3>
+          <div v-html="description"></div>
+          <dl class="dl-horizontal">
+          <dt>Last Successful Run</dt>
+          <dd><router-link v-if="lastSuccess" :to="'/jobs/'+$route.params.name+'/'+lastSuccess.number">#{{lastSuccess.number}}</router-link> {{lastSuccess?' - at '+formatDate(lastSuccess.started):'never'}}</dd>
+          <dt>Last Failed Run</dt>
+          <dd><router-link v-if="lastFailed" :to="'/jobs/'+$route.params.name+'/'+lastFailed.number">#{{lastFailed.number}}</router-link> {{lastFailed?' - at '+formatDate(lastFailed.started):'never'}}</dd>
+          </dl>
+          </div>
+          <div class="col-sm-7 col-md-6 col-lg-5">
+          <div class="panel panel-default">
+            <div class="panel-heading">Build time</div>
+            <div class="panel-body">
+            <canvas id="chartBt"></canvas>
+            </div>
+          </div>
+          </div>
+        </div>
+        <div class="row"><div class="col-xs-12">
+          <table class="table table-striped">
+          <thead><tr>
+            <th><a class="sort" :class="(sort.field=='result'?sort.order:'')" v-on:click="do_sort('result')">&nbsp;</a></th>
+            <th>Run <a class="sort" :class="(sort.field=='number'?sort.order:'')" v-on:click="do_sort('number')">&nbsp;</a></th>
+            <th class="text-center">Started <a class="sort" :class="(sort.field=='started'?sort.order:'')" v-on:click="do_sort('started')">&nbsp;</a></th>
+            <th class="text-center">Duration <a class="sort" :class="(sort.field=='duration'?sort.order:'')" v-on:click="do_sort('duration')">&nbsp;</a></th>
+            <th class="text-center hidden-xs">Reason <a class="sort" :class="(sort.field=='reason'?sort.order:'')" v-on:click="do_sort('reason')">&nbsp;</a></th>
+          </tr></thead>
+          <tr v-show="nQueued">
+            <td colspan="5"><i>{{nQueued}} run(s) queued</i></td>
+          </tr>
+          <tr v-for="job in jobsRunning" track-by="$index">
+            <td style="width:1px"><span v-html="runIcon(job.result)"></span></td>
+            <td><router-link :to="'/jobs/'+$route.params.name+'/'+job.number">#{{job.number}}</router-link></td>
+            <td class="text-center">{{formatDate(job.started)}}</td>
+            <td class="text-center">{{formatDuration(job.started, job.completed)}}</td>
+            <td class="text-center hidden-xs">{{job.reason}}</td>
+          </tr>
+          <tr v-for="job in jobsRecent" track-by="$index">
+            <td style="width:1px"><span v-html="runIcon(job.result)"></span></td>
+            <td><router-link :to="'/jobs/'+$route.params.name+'/'+job.number">#{{job.number}}</router-link></td>
+            <td class="text-center">{{formatDate(job.started)}}</td>
+            <td class="text-center">{{formatDuration(job.started, job.completed)}}</td>
+            <td class="text-center hidden-xs">{{job.reason}}</td>
+          </tr>
+          </table>
+          <ul class="pagination pull-right">
+            <li><button class="btn btn-default" v-on:click="page_prev" :disabled="sort.page==0">&laquo;</button></li>
+            <li>Page {{sort.page+1}} of {{pages}}</li>
+            <li><button class="btn btn-default" v-on:click="page_next" :disabled="sort.page==pages-1">&raquo;</button></li>
+          </ul>
+        </div></div>
+        </div>
+      </div></template>
+
+      <template id="run"><div>
+        <ol class="breadcrumb"><li><router-link to="/">Home</router-link></li><li><router-link to="/jobs">Jobs</router-link></li><li><router-link :to="'/jobs/'+$route.params.name">{{$route.params.name}}</router-link></li><li class="active">#{{$route.params.number}}</li></ol></ol>
+        <div class="container-fluid">
+        <div class="row">
+          <div class="col-sm-5 col-md-6 col-lg-7">
+          <h3 style="float:left"><span v-html="runIcon(job.result)"></span> {{$route.params.name}} #{{$route.params.number}}</h3>
+          <nav class="pull-left">
+            <ul class="pagination" style="margin:15px 20px">
+            <li v-show="$route.params.number > 1"><router-link :to="'/jobs/'+$route.params.name+'/'+($route.params.number-1)">&laquo;</router-link></li>
+            <li v-show="latestNum > $route.params.number"><router-link :to="'/jobs/'+$route.params.name+'/'+(parseInt($route.params.number)+1)">&raquo;</router-link></li>
+            </ul>
+          </nav>
+          <div style="clear:both;"></div>
+          <dl class="dl-horizontal">
+            <dt>Reason</dt><dd>{{job.reason}}</dd>
+            <dt v-show="job.upstream.num > 0">Upstream</dt><dd v-show="job.upstream.num > 0"><router-link :to="'/jobs/'+job.upstream.name">{{job.upstream.name}}</router-link> <router-link :to="'/jobs/'+job.upstream.name+'/'+job.upstream.num">#{{job.upstream.num}}</router-link></li></dd>
+            <dt>Queued for</dt><dd>{{job.queued}}s</dd>
+            <dt>Started</dt><dd>{{formatDate(job.started)}}</dd>
+            <dt v-show="runComplete(job)">Completed</dt><dd v-show="job.completed">{{formatDate(job.completed)}}</dd>
+            <dt>Duration</dt><dd>{{formatDuration(job.started, job.completed)}}</dd>
+          </dl>
+          </div>
+          <div class="col-sm-7 col-md-6 col-lg-5">
+          <div class="progress" v-show="job.result == 'running'">
+            <div class="progress-bar  progress-bar-striped" :class="'progress-bar-'+(job.overtime?'warning':'info')" :class="job.etc?'':'active'" :style="{width:!job.etc?100:job.progress + '%'}"></div>
+          </div>
+          <div class="panel panel-default" v-show="job.artifacts.length">
+            <div class="panel-heading">Artifacts</div>
+            <div class="panel-body">
+            <ul class="list-unstyled" style="margin-bottom: 0">
+              <li v-for="art in job.artifacts"><a :href="art.url" target="_self">{{art.filename}}</a> [{{ art.size | iecFileSize }}]</li>
+            </ul>
+            </div>
+          </div>
+          </div>
+        </div>
+        <div class="row"><div class="col-xs-12">
+          <button type="button" class="btn btn-default btn-xs pull-right" :class="{'active':autoscroll}" v-on:click="autoscroll = !autoscroll" style="margin-top:10px">Autoscroll</button>
+          <h4>Console output</h4>
+          <pre v-html="log"></pre>
+        </div></div>
+        </div>
+      </div></template>
+
+        <div id="app">
+            <nav class="ui left visible vertical inverted sidebar labeled icon menu">
+                <span class="item"><img class="icon" src="icon.png">{{title}}</span>
+                <router-link to="/" class="item"><i class="bar chart icon"></i>Status</router-link>
+                <router-link to="/jobs" class="item"><i class="tasks icon"></i>Jobs</router-link>
+                <a v-on:click="toggleNotifications(!notify)" v-show="supportsNotifications" class="item" :class="{'active':notify}" :title="(notify?'Disable':'Enable')+' notifications'"><i class="bell icon"></i>&#128276;</a>
+            </nav>
+            <div class="pusher">
+                <router-view></router-view>
+            </div>
+            <div v-show="!connected" id="popup-connecting"><span class="status spin">⚙&#xfe0e;</span>&nbsp;Connecting...</div>
+        </div>
+    </body>
 </html>


### PR DESCRIPTION
This is the work I did on #57. It sounds like we're not going to move forward with Semantic UI in Laminar itself, so this is more of an FYI than anything.

Commits that might still be of interest:
* a4770d9: ansi_up appears to be included twice in the laminar template right now. I imagine that browsers are smart enough to not actually include the js twice, but this might be a nice cleanup on its own.
* 2ddfe54: Having the CSS in a separate file was a little nicer for me to deal with when working on this, but is by no means necessary.