### PR TITLE
Pass reason and queuedAt to Home page

### DIFF
--- a/src/laminar.cpp
+++ b/src/laminar.cpp
@@ -361,15 +361,17 @@ std::string Laminar::getStatus(MonitorScope scope) {
         j.EndObject();
     } else { // Home page
         j.startArray("recent");
-        db->stmt("SELECT * FROM builds WHERE completedAt IS NOT NULL ORDER BY completedAt DESC LIMIT 20")
-        .fetch<str,uint,str,time_t,time_t,time_t,int>([&](str name,uint build,str context,time_t,time_t started,time_t completed,int result){
+        db->stmt("SELECT name,number,node,queuedAt,startedAt,completedAt,result,reason FROM builds WHERE completedAt IS NOT NULL ORDER BY completedAt DESC LIMIT 20")
+        .fetch<str,uint,str,time_t,time_t,time_t,int,str>([&](str name,uint build,str context,time_t queued,time_t started,time_t completed,int result,str reason){
             j.StartObject();
             j.set("name", name)
              .set("number", build)
              .set("context", context)
+             .set("queued", queued)
              .set("started", started)
              .set("completed", completed)
              .set("result", to_string(RunState(result)))
+             .set("reason", reason)
              .EndObject();
         });
         j.EndArray();


### PR DESCRIPTION
This could be useful for displaying for which reason the same job was run.
F.e. in my setup I have single `backup` job, which is then runs against different machines with different parameters.
```
LAMINAR_REASON=srv1          laminarc  queue  backup  HOST=srv1          BACKUPSERVER=shelter2.lan
LAMINAR_REASON=web1          laminarc  queue  backup  HOST=web1          BACKUPSERVER=shelter2.lan
LAMINAR_REASON=shelter       laminarc  queue  backup  HOST=shelter       BACKUPSERVER=shelter2.lan
```
Which then could be turned into this with a few tweaks in index.html
![image](https://user-images.githubusercontent.com/17022100/108602368-31149880-73aa-11eb-8831-8e2283b0e859.png)
