### PR TITLE
Allow subdirs in artifacts directory

### DIFF
--- a/src/laminar.h
+++ b/src/laminar.h
@@ -104,7 +104,7 @@ private:
     bool tryStartRun(std::shared_ptr<Run> run, int queueIndex);
     void handleRunFinished(Run*);
     // expects that Json has started an array
-    void populateArtifacts(Json& out, std::string job, uint num) const;
+    void populateArtifacts(Json& out, std::string job, uint num, kj::Path subdir = kj::Path::parse(".")) const;
 
     Run* activeRun(const std::string name, uint num) {
         auto it = activeJobs.byNameNumber().find(boost::make_tuple(name, num));


### PR DESCRIPTION
Extend populateArtifacts() with a subdir parameter (default initialized to ".")
to allow for recursive calls. With subdirs encountered, call recursively.