### PR TITLE
README: Use nproc to get cpu core count

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Then compile and install laminar with:
 git clone https://github.com/ohwgiles/laminar.git
 cd laminar
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
-make -j4
+make -j "$(nproc)"
 # Warning: the following will overwrite an existing /etc/laminar.conf
 sudo make install
 ```


### PR DESCRIPTION
This way, make will always use all the available cpu cores.