### PR TITLE
fe FreeBSD port: initial code for getting it to build, test, and run

### DIFF
--- a/src/leader.cpp
+++ b/src/leader.cpp
@@ -21,7 +21,9 @@
 #include <unistd.h>
 #include <queue>
 #include <dirent.h>
+#if !defined(__FreeBSD__)
 #include <sys/prctl.h>
+#endif
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <kj/async-io.h>
@@ -313,12 +315,14 @@ int leader_main(void) {
     // reap orphaned child processes. Stick with the more fundamental onSignal.
     kj::UnixEventPort::captureSignal(SIGCHLD);
 
+#if !defined(__FreeBSD__)
     // Becoming a subreaper means any descendent process whose parent process disappears
     // will be reparented to this one instead of init (or higher layer subreaper).
     // We do this so that the run will wait until all descedents exit before executing
     // the next step.
     prctl(PR_SET_CHILD_SUBREAPER, 1, NULL, NULL, NULL);
-
+#endif
+    
     // Become the leader of a new process group. This is so that all child processes
     // will also get a kill signal when the run is aborted
     setpgid(0, 0);

--- a/src/run.cpp
+++ b/src/run.cpp
@@ -25,6 +25,10 @@
 #include <unistd.h>
 #include <signal.h>
 
+#if defined(__FreeBSD__)
+#include <sys/wait.h>
+#endif
+
 // short syntax helper for kj::Path
 template<typename T>
 inline kj::Path operator/(const kj::Path& p, const T& ext) {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -29,7 +29,9 @@
 #include <signal.h>
 #include <sys/eventfd.h>
 #include <sys/inotify.h>
+#if !defined(__FreeBSD__)
 #include <sys/signalfd.h>
+#endif
 #include <sys/stat.h>
 
 // Size of buffer used to read from file descriptors. Should be

--- a/test/eventsource.h
+++ b/test/eventsource.h
@@ -24,6 +24,12 @@
 #include <rapidjson/document.h>
 #include <vector>
 
+#if defined(__FreeBSD__)
+#include <unistd.h>
+typedef u_long ulong;
+using namespace std;
+#endif
+
 class EventSource {
 public:
     EventSource(kj::AsyncIoContext& ctx, const char* httpConnectAddr, const char* path) :


### PR DESCRIPTION
Turns out that getting it ported over wasn't all that difficult. Most of the code and dependencies have already 
been ported over to FreeBSD. It's not perfect, though.

### To compile with GCC:
1) Install all of the libraries from the Debian Bullseye instructions + the libinotify port and gcc12
2) Run `mkdir build` in the laminar root directory and cd into it (this is a common practice when using cmake)
3) Run `cmake ../ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_CXX_STANDARD=11 -DCMAKE_CXX_COMPILER="/usr/local/bin/g++12" -DCMAKE_C_COMPILER="/usr/local/bin/gcc12" -DCMAKE_CXX_FLAGS="-I/usr/local/include -Wl,-rpath=/usr/local/lib/gcc12 -L/usr/local/lib -lpthread -linotify -lgtest -lgmock" -DBUILD_TESTS=TRUE`
FreeBSD defaults to using clang for everything unless you explicitly tell it otherwise and needs some extra flags to get everything configured correctly
4) Run `cmake --build . -j $(nproc)` and hopefully everything will go without issues.

### Current issues:
1) FreeBSD's standard library seems to have issues with how the shared_ptrs are used; all supported versions 
    of Clang have problems handling them while GCC is fine.
2) GCC is no longer officially supported or the recommended compiler for FreeBSD but multiple versions of it 
    compiled the code and tests fine. There may be bugs long term.
3) The server seems to segfault due to library permission issues if built within a jail with hardened settings configured 
(can sort of be partially solved by building with `-static-libgcc -static-libstdc++` in the -DCMAKE_CXX_FLAGS string 
from above but I'm not sure how problematic that can be yet.

### Tested on:
FreeBSD 13.1-RC6 (main official release coming in the next day or two)
3-core 2.6GHz Intel Xeon server processor
4GB DDR4 RAM
Built inside of a BastilleBSD jail (think FreeBSD native version of Docker with some twists)