### PR TITLE
Update Chart.js to version 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,8 @@ file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.12/vue.min.js
 	js/vue.min.js EXPECTED_MD5 fb192338844efe86ec759a40152fcb8e)
 file(DOWNLOAD https://raw.githubusercontent.com/drudru/ansi_up/v4.0.4/ansi_up.js
         js/ansi_up.js EXPECTED_MD5 b31968e1a8fed0fa82305e978161f7f5)
-file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js
-        js/Chart.min.js EXPECTED_MD5 f6c8efa65711e0cbbc99ba72997ecd0e)
+file(DOWNLOAD https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js
+        js/Chart.min.js EXPECTED_MD5 7dd5ea7d2cf22a1c42b43c40093d2669)
 # ...and compile them
 generate_compressed_bins(${CMAKE_BINARY_DIR} js/vue.min.js
     js/ansi_up.js js/Chart.min.js)

--- a/src/resources/js/app.js
+++ b/src/resources/js/app.js
@@ -129,7 +129,8 @@ const Charts = (() => {
           }]
         },
         options: {
-          hover: { mode: null }
+          hover: { mode: null },
+          aspectRatio: 2
         }
       });
       c.executorBusyChanged = busy => {
@@ -161,11 +162,13 @@ const Charts = (() => {
             backgroundColor: "#883d3d",
             data: data.map(e => e.failed || 0),
             fill: true,
+            tension: 0.35,
           },{
             label: 'Successful Builds',
             backgroundColor: "#74af77",
             data: data.map(e => e.success || 0),
             fill: true,
+            tension: 0.35,
           }]
         },
         options:{
@@ -279,7 +282,8 @@ const Charts = (() => {
         label: name,
         data: durations.map(x => x * scale.factor),
         borderColor: 'hsl('+(name.hashCode() % 360)+', 27%, 57%)',
-        backgroundColor: 'transparent'
+        backgroundColor: 'transparent',
+        tension: 0.35,
       });
       const c = new Chart(document.getElementById(id), {
         type: 'line',
@@ -389,7 +393,7 @@ const Charts = (() => {
 })();
 
 // For all charts, set miniumum Y to 0
-Chart.defaults.scales.linear = { ticks: { suggestedMin: 0 } };
+Chart.defaults.scales.linear.suggestedMin = 0;
 // Don't display legend by default
 Chart.defaults.plugins.legend.display = false;
 // Disable tooltip hover animations


### PR DESCRIPTION
I hope this can be useful!

This PR updates Chart.js to the latest version.
A detail list of the changes can be seen in the commit message, with links to the migration guide.

I've visually checked some graphs, but as I am new to Laminar itself, maybe I missed something. One thing I did catch is a difference in the Runtime chart (where it shows the built time of jobs and an average). Here is a comparison between them, see the average line:
<img width="711" alt="Screen Shot 2022-09-28 at 00 25 26" src="https://user-images.githubusercontent.com/4899111/192649375-e770a835-8f33-46e6-98b5-cf23053aecf0.png">

With my patches:
<img width="708" alt="Screen Shot 2022-09-28 at 00 24 52" src="https://user-images.githubusercontent.com/4899111/192649419-cb7176cc-10ef-46a2-87c6-b89ca84b5d28.png">

I've tried a few things, but couldn't make it look like as before. One suggestion I can think of is using [chartjs-plugin-annotation](https://www.chartjs.org/chartjs-plugin-annotation/latest/guide/types/line.html)

Fixes #175 