### PR TITLE
Fix wrong example path extension

### DIFF
--- a/UserManual.md
+++ b/UserManual.md
@@ -534,7 +534,7 @@ If `CONTEXTS` is empty or absent (or if `JOB.conf` doesn't exist), laminar will 
 
 ## Adding environment to a context
 
-Append desired environment variables to `/var/lib/laminar/cfg/contexts/CONTEXT_NAME.conf`:
+Append desired environment variables to `/var/lib/laminar/cfg/contexts/CONTEXT_NAME.env`:
 
 ```
 DUT_IP=192.168.3.2


### PR DESCRIPTION
A few lines down the "context’s `.env` file" file is mentioned but I couldn't find the original example.