### PR TITLE
Fix author warning about cmake command order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,8 @@
 ### You should have received a copy of the GNU General Public License
 ### along with Laminar.  If not, see <http://www.gnu.org/licenses/>
 ###
-project(laminar)
 cmake_minimum_required(VERSION 3.6)
+project(laminar)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
This PR is a proposed fix for an author warning issued about cmake command order when using cmake-3.26.0 or later.

Please review and merge, or let me know how to improve it.

---

While building Laminar on Gentoo, I noticed an author warning about an incorrect cmake command order:

```
CMake Warning (dev) at CMakeLists.txt:19 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

It appeared in CMake 3.26.0, according to the [Other Changes](https://cmake.org/cmake/help/latest/release/3.26.html#other-changes) section of the release notes.