### PR TITLE
added support for build.env

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,9 @@ endif()
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_STANDARD 17)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare" )
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=deprecated-declarations" )
+
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Werror -DDEBUG")
 
 # Allow passing in the version string, for e.g. patched/packaged versions

--- a/UserManual.md
+++ b/UserManual.md
@@ -706,6 +706,17 @@ Note that definitions in these files are not expanded by a shell, so `FOO="bar"`
 
 Finally, variables supplied on the command-line call to `laminarc queue`, `laminarc start` or `laminarc run` will be available. See [parameterized runs](#Parameterized-runs)
 
+## Feedback environment variables
+
+The build scripts can send back environment variables to laminar. Therefore it 
+can create an file "build.env" in the build folder. After the build, the file 
+is parsed.
+
+The following variables are used by laminar:
+
+- `SOURCE_BRANCH` branch that was used in the SCM-checkout (git, svn etc) for building
+- `SOURCE_VERSION` release version of the build
+
 ## laminarc
 
 `laminarc` commands are:

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -46,8 +46,11 @@ static int setParams(int argc, char** argv, T& request) {
     char* job = getenv("JOB");
     char* num = getenv("RUN");
     char* reason = getenv("LAMINAR_REASON");
+    char* srcBranch = getenv("SOURCE_BRANCH");
+    char* srcVersion = getenv("SOURCE_VERSION");
 
-    auto params = request.initParams(n + (job&&num?2:0) + (reason?1:0));
+    auto params = request.initParams(n + (job&&num?2:0) + (reason?1:0)
+                                     + (srcBranch?1:0) + (srcVersion?1:0) );
 
     for(int i = 0; i < n; ++i) {
         char* name = argv[i];
@@ -67,7 +70,15 @@ static int setParams(int argc, char** argv, T& request) {
     }
     if(reason) {
         params[n].setName("=reason");
-        params[n].setValue(reason);
+        params[n++].setValue(reason);
+    }
+    if(srcBranch) {
+        params[n].setName("=sourceBranch");
+        params[n++].setValue(srcBranch);
+    }
+    if(srcVersion) {
+        params[n].setName("=sourceVersion");
+        params[n++].setValue(srcVersion);
     }
 
     return argsConsumed;

--- a/src/resources/index.html
+++ b/src/resources/index.html
@@ -138,6 +138,8 @@
      <th class="text-center">Started <a class="sort" :class="(sort.field=='started'?sort.order:'')" v-on:click="do_sort('started')">&nbsp;</a></th>
      <th class="text-center">Duration <a class="sort" :class="(sort.field=='duration'?sort.order:'')" v-on:click="do_sort('duration')">&nbsp;</a></th>
      <th class="text-center vp-sm-hide">Reason <a class="sort" :class="(sort.field=='reason'?sort.order:'')" v-on:click="do_sort('reason')">&nbsp;</a></th>
+     <th class="text-center vp-sm-hide">Branch <a class="sort" :class="(sort.field=='sourceBranch'?sort.order:'')" v-on:click="do_sort('sourceBranch')">&nbsp;</a></th>
+     <th class="text-center vp-sm-hide">Version <a class="sort" :class="(sort.field=='sourceVersion'?sort.order:'')" v-on:click="do_sort('sourceVersion')">&nbsp;</a></th>
     </tr></thead>
     <tr v-for="job in jobsQueued.concat(jobsRunning).concat(jobsRecent)" track-by="$index">
      <td style="width:1px"><span v-html="runIcon(job.result)"></span></td>
@@ -145,6 +147,8 @@
      <td class="text-center"><span v-if="job.result!='queued'">{{formatDate(job.started)}}</span></td>
      <td class="text-center"><span v-if="job.result!='queued'">{{formatDuration(job.started, job.completed)}}</span></td>
      <td class="text-center vp-sm-hide">{{job.reason}}</td>
+     <td class="text-center vp-sm-hide">{{job.sourceBranch}}</td>
+     <td class="text-center vp-sm-hide">{{job.sourceVersion}}</td>
     </tr>
    </table>
    <div style="float: right; margin: 15px; display: inline-grid; grid-auto-flow: column; gap: 10px; align-items: center">
@@ -176,8 +180,10 @@
      <dt v-show="runComplete(job)">Completed</dt><dd v-show="job.completed">{{formatDate(job.completed)}}</dd>
      <dt v-show="job.started">Duration</dt><dd v-show="job.started">{{formatDuration(job.started, job.completed)}}</dd>
     </dl>
-    <dl v-show="job.artifacts.length">
-     <dt>Artifacts</dt>
+    <dl>
+     <dt v-show="job.sourceBranch.length">Branch</dt><dd>{{job.sourceBranch}}</dd>
+     <dt v-show="job.sourceVersion.length">Version</dt><dd>{{job.sourceVersion}}</dd>
+     <dt v-show="job.artifacts.length">Artifacts</dt>
      <dd>
       <ul style="margin-bottom: 0">
        <li v-for="art in job.artifacts"><a :href="art.url" target="_self">{{art.filename}}</a> [{{ art.size | iecFileSize }}]</li>

--- a/src/resources/style.css
+++ b/src/resources/style.css
@@ -318,6 +318,7 @@ button:not([disabled]) { cursor: pointer; color: var(--main-fg); }
 #page-run-detail {
   display: grid;
   grid-template-columns: minmax(400px, auto) 1fr;
+  align-items: start;
   gap: 5px;
 }
 @media (max-width: 780px) {

--- a/src/run.h
+++ b/src/run.h
@@ -61,8 +61,11 @@ public:
 
     // aborts this run
     bool abort();
-
+    
+    bool digestBuildEnv(const kj::Directory &fsHome);
     std::string reason() const;
+    std::string sourceBranch() const;
+    std::string sourceVersion() const;
 
     kj::Promise<void> whenStarted() { return startedFork.addBranch(); }
     kj::Promise<RunState> whenFinished() { return finishedFork.addBranch(); }
@@ -96,6 +99,8 @@ private:
 
     kj::Path rootPath;
     std::string reasonMsg;
+    std::string sourceBranchStr;
+    std::string sourceVersionStr;
 
     kj::PromiseFulfillerPair<void> started;
     kj::ForkedPromise<void> startedFork;


### PR DESCRIPTION
The build scripts can create an file "build.env" in the build folder to feed back environment variables to laminar.
After the build, the file is parsed by laminar.

The following variables are used by laminar:

- `SOURCE_BRANCH` branch used in the SCM-checkout (e.g git) for building
- `SOURCE_VERSION` release version of the build