### PR TITLE
Fix mix of tabs/spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ First install development packages for `capnproto (version 0.7.0 or newer)`, `ra
 On Debian Bullseye, this can be done with:
 
 ```bash
-sudo apt install \
-		 capnproto cmake g++ libboost-dev libcapnp-dev \
-     libsqlite3-dev rapidjson-dev zlib1g-dev pkg-config
+sudo apt install capnproto cmake g++ libboost-dev libcapnp-dev libsqlite3-dev \
+  rapidjson-dev zlib1g-dev pkg-config
 ```
 
 Then compile and install laminar with:


### PR DESCRIPTION
The bash code block to install packages were mixing spaces and tabs in the breaking lines.

Removed tabs and spaces, to only use 2 spaces.

Also wrap at 80 characters.