### PR TITLE
.deb build scripts for Debian 12 and 13

### DIFF
--- a/pkg/debian12-amd64.sh
+++ b/pkg/debian12-amd64.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+
+set -ex
+
+OUTPUT_DIR=$PWD
+
+SOURCE_DIR=$(readlink -f $(dirname ${BASH_SOURCE[0]})/..)
+
+VERSION=$(cd "$SOURCE_DIR" && git describe --tags --abbrev=8 --dirty)-1~upstream-debian12
+
+DOCKER_TAG=$(docker build -q - <<EOS
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y wget cmake g++ capnproto libcapnp-dev rapidjson-dev libsqlite3-dev libboost-dev zlib1g-dev pkg-config
+EOS
+)
+
+docker run --rm -i -v $SOURCE_DIR:/laminar:ro -v $OUTPUT_DIR:/output $DOCKER_TAG bash -xe <<EOS
+
+mkdir /build
+cd /build
+
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DLAMINAR_VERSION=$VERSION -DZSH_COMPLETIONS_DIR=/usr/share/zsh/functions/Completion/Unix /laminar
+make -j4
+mkdir laminar
+make DESTDIR=laminar install/strip
+
+mkdir laminar/DEBIAN
+cat <<EOF > laminar/DEBIAN/control
+Package: laminar
+Version: $VERSION
+Section: 
+Priority: optional
+Architecture: amd64
+Maintainer: Oliver Giles <web ohwg net>
+Depends: libcapnp-1.0.1, libsqlite3-0, zlib1g
+Description: Lightweight Continuous Integration Service
+EOF
+echo /etc/laminar.conf > laminar/DEBIAN/conffiles
+cat <<EOF > laminar/DEBIAN/postinst
+#!/bin/bash
+echo Creating laminar user with home in /var/lib/laminar
+useradd -r -d /var/lib/laminar -s /usr/sbin/nologin laminar
+mkdir -p /var/lib/laminar/cfg/{jobs,contexts,scripts}
+chown -R laminar: /var/lib/laminar
+EOF
+chmod +x laminar/DEBIAN/postinst
+
+dpkg-deb --build laminar
+mv laminar.deb /output/laminar_${VERSION}_amd64.deb
+EOS

--- a/pkg/debian13-amd64.sh
+++ b/pkg/debian13-amd64.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+
+set -ex
+
+OUTPUT_DIR=$PWD
+
+SOURCE_DIR=$(readlink -f $(dirname ${BASH_SOURCE[0]})/..)
+
+VERSION=$(cd "$SOURCE_DIR" && git describe --tags --abbrev=8 --dirty)-1~upstream-debian13
+
+DOCKER_TAG=$(docker build -q - <<EOS
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y wget cmake g++ capnproto libcapnp-dev rapidjson-dev libsqlite3-dev libboost-dev zlib1g-dev pkg-config
+EOS
+)
+
+docker run --rm -i -v $SOURCE_DIR:/laminar:ro -v $OUTPUT_DIR:/output $DOCKER_TAG bash -xe <<EOS
+
+mkdir /build
+cd /build
+
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DLAMINAR_VERSION=$VERSION -DZSH_COMPLETIONS_DIR=/usr/share/zsh/functions/Completion/Unix /laminar
+make -j4
+mkdir laminar
+make DESTDIR=laminar install/strip
+
+mkdir laminar/DEBIAN
+cat <<EOF > laminar/DEBIAN/control
+Package: laminar
+Version: $VERSION
+Section: 
+Priority: optional
+Architecture: amd64
+Maintainer: Oliver Giles <web ohwg net>
+Depends: libcapnp-1.0.1, libsqlite3-0, zlib1g
+Description: Lightweight Continuous Integration Service
+EOF
+echo /etc/laminar.conf > laminar/DEBIAN/conffiles
+cat <<EOF > laminar/DEBIAN/postinst
+#!/bin/bash
+echo Creating laminar user with home in /var/lib/laminar
+useradd -r -d /var/lib/laminar -s /usr/sbin/nologin laminar
+mkdir -p /var/lib/laminar/cfg/{jobs,contexts,scripts}
+chown -R laminar: /var/lib/laminar
+EOF
+chmod +x laminar/DEBIAN/postinst
+
+dpkg-deb --build laminar
+mv laminar.deb /output/laminar_${VERSION}_amd64.deb
+EOS


### PR DESCRIPTION
Hi! Here's package build scripts similar to `pkg/debian11-amd64.sh` that will create working packages for install on Debian 12 (bookworm) and Debian 13 (trixie), amd64 architecture only.

I tried to create these each as a minimal diff from `pkg/debian11-amd64.sh`. Given the amount of duplicated code across the three files as well as the armhf build script it would probably be a good next step to collapse them into a single parameterized script.