### PR TITLE
Fix version of libcapnp in `pkg/debian12-amd64.sh`

### DIFF
--- a/pkg/debian12-amd64.sh
+++ b/pkg/debian12-amd64.sh
@@ -32,7 +32,7 @@ Section:
 Priority: optional
 Architecture: amd64
 Maintainer: Oliver Giles <web ohwg net>
-Depends: libcapnp-1.0.1, libsqlite3-0, zlib1g
+Depends: libcapnp-0.9.2, libsqlite3-0, zlib1g
 Description: Lightweight Continuous Integration Service
 EOF
 echo /etc/laminar.conf > laminar/DEBIAN/conffiles


### PR DESCRIPTION
Debian 12 includes libcapnp-0.9.2, not libcapnp-1.0.1:

https://packages.debian.org/bookworm/libcapnp-0.9.2